### PR TITLE
Fix false deadlock.

### DIFF
--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -450,9 +450,6 @@ func NewNode(process *Process) *Node {
 }
 
 func (n *Node) Duplicate(other *Node) {
-	if !n.Enabled {
-		return
-	}
 	parent := n.Inbound[0].Node
 	other.Inbound = append(other.Inbound, n.Inbound[0])
 	parent.Outbound = append(parent.Outbound, &Link{


### PR DESCRIPTION
Even if the current node is not enabled yet, it might get enabled in the future steps, so mark it as duplicate to preserve the link and avoid the spurious deadlock error