### PR TITLE
Basic version of simulation mode.

### DIFF
--- a/fizz
+++ b/fizz
@@ -1,10 +1,42 @@
 #!/bin/bash
 #bazel-bin/parser/parser_bin $1 > parserout.log
 
-# Check if the correct number of arguments is provided
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <input_filename>"
-    exit 1
+usage() {
+  echo "Usage: $0 [-x|--simulation] filename"
+  exit 1
+}
+
+# Initialize variables
+simulation=false
+
+# Parse options
+while [[ "$1" =~ ^- ]]; do
+  case $1 in
+    -x | --simulation )
+      simulation=true
+      shift
+      ;;
+    -h | --help )
+      usage
+      ;;
+    * )
+      echo "Invalid option: $1" 1>&2
+      usage
+      ;;
+  esac
+done
+
+# Check for the required positional argument
+if [ -z "$1" ]; then
+  echo "Error: filename is required" 1>&2
+  usage
+fi
+
+input_filename=$1
+
+# Example usage of the parsed options and arguments
+if [ "$simulation" = true ]; then
+  echo "Simulation mode is enabled"
 fi
 
 input_filename=$1
@@ -30,8 +62,17 @@ fi
 json_filename="${input_filename%.*}.json"
 
 echo "Model checking" $json_filename
+
+# Prepare arguments for the Go binary
+args=()
+if [ "$simulation" = true ]; then
+  args+=("--simulation")
+fi
+args+=("$json_filename")
+
+
 # Run the second command with the JSON filename
-bazel-bin/fizzbee_/fizzbee "$json_filename"
+bazel-bin/fizzbee_/fizzbee "${args[@]}"
 
 # Clean up the temporary file
 rm "$temp_output"

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "lib",
     srcs = [
         "jsonmarshaller.go",
+        "linear_collection.go",
         "permutations.go",
         "queue.go",
         "stack.go",

--- a/lib/linear_collection.go
+++ b/lib/linear_collection.go
@@ -1,0 +1,8 @@
+package lib
+
+type LinearCollection[T any] interface {
+    Len() int
+    Empty() bool
+    Add(T)
+    Remove() (T, bool)
+}

--- a/lib/queue.go
+++ b/lib/queue.go
@@ -17,6 +17,22 @@ type Queue[T any] struct {
     count int
 }
 
+func (q *Queue[T]) Len() int {
+    return q.Count()
+}
+
+func (q *Queue[T]) Empty() bool {
+    return q.Empty()
+}
+
+func (q *Queue[T]) Add(t T) {
+    q.Enqueue(t)
+}
+
+func (q *Queue[T]) Remove() (T, bool) {
+    return q.Dequeue()
+}
+
 func NewQueue[T any]() *Queue[T] {
     return &Queue[T]{sync.Mutex{}, list.New(), 0}
 }
@@ -58,3 +74,5 @@ func (q *Queue[T]) Count() int {
     return q.count
 }
 
+// Ensures Queue implements LinearCollection
+var _ LinearCollection[interface{}] = (*(Queue[interface{}]))(nil)

--- a/lib/stack.go
+++ b/lib/stack.go
@@ -16,6 +16,18 @@ type Stack[T any] struct {
 	head *T
 }
 
+func (s *Stack[T]) Empty() bool {
+	return s.Empty()
+}
+
+func (s *Stack[T]) Add(t T) {
+	s.Push(t)
+}
+
+func (s *Stack[T]) Remove() (T, bool) {
+	return s.Pop()
+}
+
 func NewStack[T any]() *Stack[T] {
 	return &Stack[T]{sync.Mutex{}, make([]T, 0, 10), nil, nil}
 }
@@ -103,3 +115,7 @@ func (s *Stack[T]) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(s.s)
 }
+
+
+// Ensures Queue implements LinearCollection
+var _ LinearCollection[interface{}] = (*(Stack[interface{}]))(nil)

--- a/modelchecker/markovchain_test.go
+++ b/modelchecker/markovchain_test.go
@@ -143,7 +143,7 @@ func TestSteadyStateDistribution(t *testing.T) {
 					},
 				}
 			}
-			p1 := NewProcessor(files, stateCfg)
+			p1 := NewProcessor(files, stateCfg, false)
 			root, _, _ := p1.Start()
 			//RemoveMergeNodes(root)
 

--- a/modelchecker/processor_test.go
+++ b/modelchecker/processor_test.go
@@ -96,9 +96,9 @@ func TestProcessor_Start(t *testing.T) {
 	files := []*ast.File{file}
 	p1 := NewProcessor(files, &ast.StateSpaceOptions{
 		Options: &ast.Options{
-			MaxActions:           1,
+			MaxActions: 1,
 		},
-	})
+	}, false)
 	root, _, _ := p1.Start()
 	assert.NotNil(t, root)
 	assert.Equal(t, 91, len(p1.visited))
@@ -532,7 +532,7 @@ func TestProcessor_Tutorials(t *testing.T) {
 				}
 			}
 
-			p1 := NewProcessor(files, stateConfig)
+			p1 := NewProcessor(files, stateConfig, false)
 			startTime := time.Now()
 			root, _, err := p1.Start()
 			require.Nil(t, err)


### PR DESCRIPTION
Added a command line flag --simulation that runs in simulation mode.

At present, it is simply using stack (DFS) instead of a queue (BFS). This doesn't use any additional optimizations that are typically possible for simulation like in TLC's implementation.

At present, only safety checks are supported.