### PR TITLE
Speedup modelchecking by removing redundant work

### DIFF
--- a/fizz
+++ b/fizz
@@ -16,6 +16,10 @@ while [[ "$1" =~ ^- ]]; do
       simulation=true
       shift
       ;;
+    --internal_profile )
+      internal_profile=true
+      shift
+      ;;
     -h | --help )
       usage
       ;;
@@ -67,6 +71,9 @@ echo "Model checking" $json_filename
 args=()
 if [ "$simulation" = true ]; then
   args+=("--simulation")
+fi
+if [ "$internal_profile" = true ]; then
+  args+=("--internal_profile")
 fi
 args+=("$json_filename")
 

--- a/lib/queue.go
+++ b/lib/queue.go
@@ -55,11 +55,12 @@ func (q *Queue[T]) Dequeue() (T, bool) {
     q.lock.Lock()
     defer q.lock.Unlock()
     front := q.list.Front()
+    var v T
     if front == nil {
-        var v T
         return v, false
     }
     res := front.Value.([]T)[0]
+    front.Value.([]T)[0] = v
     front.Value = front.Value.([]T)[1:]
     if len(front.Value.([]T)) == 0 {
         q.list.Remove(front)

--- a/lib/stack.go
+++ b/lib/stack.go
@@ -54,6 +54,7 @@ func (s *Stack[T]) Pop() (T, bool) {
 	}
 
 	res := s.s[l-1]
+	s.s[l-1] = v
 	s.s = s.s[:l-1]
 	if l > 1 {
 		s.peak = &s.s[l-2]

--- a/main.go
+++ b/main.go
@@ -21,12 +21,12 @@ import (
 
 var isPlayground bool
 var simulation bool
-var internal_profile bool
+var internalProfile bool
 
 func main() {
     flag.BoolVar(&isPlayground, "playground", false, "is for playground")
     flag.BoolVar(&simulation, "simulation", false, "Runs in simulation mode (DFS). Default=false for no simulation (BFS)")
-    flag.BoolVar(&internal_profile, "internal_profile", false, "Enables CPU and memory profiling of the model checker")
+    flag.BoolVar(&internalProfile, "internal_profile", false, "Enables CPU and memory profiling of the model checker")
     flag.Parse()
 
     args := flag.Args()
@@ -179,7 +179,7 @@ func main() {
 }
 
 func startModelChecker(err error, p1 *modelchecker.Processor) (*modelchecker.Node, *modelchecker.Node, time.Time) {
-    if internal_profile {
+    if internalProfile {
         startCpuProfile()
         defer pprof.StopCPUProfile()
     }
@@ -187,7 +187,7 @@ func startModelChecker(err error, p1 *modelchecker.Processor) (*modelchecker.Nod
     rootNode, failedNode, err := p1.Start()
     endTime := time.Now()
     fmt.Printf("Time taken for model checking: %v\n", endTime.Sub(startTime))
-    if internal_profile {
+    if internalProfile {
         startHeapProfile()
     }
     return rootNode, failedNode, endTime

--- a/main.go
+++ b/main.go
@@ -132,20 +132,22 @@ func main() {
         var failurePath []*modelchecker.Link
         var failedInvariant *modelchecker.InvariantPosition
         nodes, deadlock, _ := modelchecker.GetAllNodes(rootNode)
-        if deadlock != nil && stateConfig.GetDeadlockDetection() {
+        if deadlock != nil && stateConfig.GetDeadlockDetection() && !p1.Stopped() {
             fmt.Println("DEADLOCK detected")
             fmt.Println("FAILED: Model checker failed")
             dumpFailedNode(deadlock, rootNode, outDir)
             return
         }
-        if stateConfig.GetLiveness() == "" || stateConfig.GetLiveness() == "strict" || stateConfig.GetLiveness() == "strict/bfs" {
-            failurePath, failedInvariant = modelchecker.CheckStrictLiveness(rootNode)
-            fmt.Printf("IsLive: %t\n", failedInvariant == nil)
-            fmt.Printf("Time taken to check liveness: %v\n", time.Now().Sub(endTime))
-        } else if stateConfig.GetLiveness() == "eventual" {
-            failurePath, failedInvariant = modelchecker.CheckFastLiveness(nodes)
-            fmt.Printf("IsLive: %t\n", failedInvariant == nil)
-            fmt.Printf("Time taken to check liveness: %v\n", time.Now().Sub(endTime))
+        if !p1.Stopped() {
+            if stateConfig.GetLiveness() == "" || stateConfig.GetLiveness() == "strict" || stateConfig.GetLiveness() == "strict/bfs" {
+                failurePath, failedInvariant = modelchecker.CheckStrictLiveness(rootNode)
+                fmt.Printf("IsLive: %t\n", failedInvariant == nil)
+                fmt.Printf("Time taken to check liveness: %v\n", time.Now().Sub(endTime))
+            } else if stateConfig.GetLiveness() == "eventual" {
+                failurePath, failedInvariant = modelchecker.CheckFastLiveness(nodes)
+                fmt.Printf("IsLive: %t\n", failedInvariant == nil)
+                fmt.Printf("Time taken to check liveness: %v\n", time.Now().Sub(endTime))
+            }
         }
 
         if failedInvariant == nil {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
     "os"
     "os/signal"
     "path/filepath"
+    "runtime/pprof"
     "slices"
     "strings"
     "syscall"
@@ -20,10 +21,12 @@ import (
 
 var isPlayground bool
 var simulation bool
+var internal_profile bool
 
 func main() {
     flag.BoolVar(&isPlayground, "playground", false, "is for playground")
     flag.BoolVar(&simulation, "simulation", false, "Runs in simulation mode (DFS). Default=false for no simulation (BFS)")
+    flag.BoolVar(&internal_profile, "internal_profile", false, "Enables CPU and memory profiling of the model checker")
     flag.Parse()
 
     args := flag.Args()
@@ -87,10 +90,9 @@ func main() {
         fmt.Println("\nInterrupted. Stopping state exploration")
         p1.Stop()
     }()
-    startTime := time.Now()
-    rootNode, failedNode, err := p1.Start()
-    endTime := time.Now()
-    fmt.Printf("Time taken for model checking: %v\n", endTime.Sub(startTime))
+
+    rootNode, failedNode, endTime := startModelChecker(err, p1)
+
     outDir, err := createOutputDir(dirPath)
     if err != nil {
         return
@@ -173,6 +175,45 @@ func main() {
 
     dumpFailedNode(failedNode, rootNode, outDir)
 }
+
+func startModelChecker(err error, p1 *modelchecker.Processor) (*modelchecker.Node, *modelchecker.Node, time.Time) {
+    if internal_profile {
+        startCpuProfile()
+        defer pprof.StopCPUProfile()
+    }
+    startTime := time.Now()
+    rootNode, failedNode, err := p1.Start()
+    endTime := time.Now()
+    fmt.Printf("Time taken for model checking: %v\n", endTime.Sub(startTime))
+    if internal_profile {
+        startHeapProfile()
+    }
+    return rootNode, failedNode, endTime
+}
+
+func startCpuProfile() {
+    // Start CPU profiling
+    f, err := os.Create("cpu.pprof")
+    if err != nil {
+        panic(err)
+    }
+    err = pprof.StartCPUProfile(f)
+    if err != nil {
+        panic(err)
+    }
+}
+
+func startHeapProfile() {
+    f, err := os.Create("mem.pprof")
+    if err != nil {
+        panic(err)
+    }
+    err = pprof.WriteHeapProfile(f)
+    if err != nil {
+        panic(err)
+    }
+}
+
 
 func dumpFailedNode(failedNode *modelchecker.Node, rootNode *modelchecker.Node, outDir string) {
     failurePath := make([]*modelchecker.Link, 0)

--- a/modelchecker/clone.go
+++ b/modelchecker/clone.go
@@ -46,7 +46,7 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
         if err != nil {
             return nil, err
         }
-        newSet := starlark.NewSet(10)
+        newSet := starlark.NewSet(len(newList))
         for _, v := range newList {
             err := newSet.Insert(v)
             if err != nil {
@@ -190,6 +190,7 @@ func deepCloneStringDict(v *starlark.Dict, refs map[string]*Role, src map[lib.Sy
 func deepCloneIterableToList(iterable starlark.Iterable, refs map[string]*Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) ([]starlark.Value, error) {
     var newList []starlark.Value
     iter := iterable.Iterate()
+    defer iter.Done()
     var x starlark.Value
     for iter.Next(&x) {
         clonedElem, err := deepCloneStarlarkValueWithPermutations(x, refs, permutations, alt)

--- a/modelchecker/options.go
+++ b/modelchecker/options.go
@@ -14,7 +14,7 @@ func ReadOptionsFromYaml(filename string) (*proto.StateSpaceOptions, error) {
 	if msg.Options == nil {
 		msg.Options = &proto.Options{
 			MaxActions:            100,
-			MaxConcurrentActions:  5,
+			MaxConcurrentActions:  2,
 		}
 	}
 	if msg.Options.MaxConcurrentActions == 0 {

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -654,16 +654,12 @@ func (n *Node) Duplicate(other *Node, yield bool) {
 		Fairness: n.Inbound[0].Fairness,
 		Messages: n.Inbound[0].Messages,
 	})
-<<<<<<< Updated upstream
-=======
-	//maps.Copy(other.ancestors, n.ancestors)
+
+	n.Process = nil
+	n.Inbound = nil
+	n.Outbound = nil
 }
 
-func (n *Node) Stutter() {
-	//n.Outbound = append(n.Outbound, &Link{Node: n, Name: "stutter"})
-	//n.Inbound = append(n.Inbound, &Link{Node: n, Name: "stutter"})
->>>>>>> Stashed changes
-}
 
 func (n *Node) Attach() {
 	if len(n.Inbound) == 0 {

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -654,6 +654,15 @@ func (n *Node) Duplicate(other *Node, yield bool) {
 		Fairness: n.Inbound[0].Fairness,
 		Messages: n.Inbound[0].Messages,
 	})
+<<<<<<< Updated upstream
+=======
+	//maps.Copy(other.ancestors, n.ancestors)
+}
+
+func (n *Node) Stutter() {
+	//n.Outbound = append(n.Outbound, &Link{Node: n, Name: "stutter"})
+	//n.Inbound = append(n.Inbound, &Link{Node: n, Name: "stutter"})
+>>>>>>> Stashed changes
 }
 
 func (n *Node) Attach() {

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -111,6 +111,8 @@ type Process struct {
 	Enabled		bool                   `json:"-"`
 
 	Roles 	    []*Role                `json:"roles"`
+
+	CachedHashCode string              `json:"-"`
 }
 
 func NewProcess(name string, files []*ast.File, parent *Process) *Process {
@@ -389,6 +391,9 @@ func (n *Node) GetName() string {
 }
 
 func (p *Process) HashCode() string {
+	if p.CachedHashCode != "" {
+		return p.CachedHashCode
+	}
 	threadHashes := make([]string, len(p.Threads))
 	for i, thread := range p.Threads {
 		threadHashes[i] = thread.HashCode()
@@ -414,7 +419,8 @@ func (p *Process) HashCode() string {
 	// hash the heap variables as well
 	heapHash := p.Heap.HashCode()
 	h.Write([]byte(heapHash))
-	return fmt.Sprintf("%x", h.Sum(nil))
+	p.CachedHashCode = fmt.Sprintf("%x", h.Sum(nil))
+	return p.CachedHashCode
 }
 
 func (p *Process) currentThread() *Thread {

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -828,8 +828,9 @@ func (p *Processor) Start() (init *Node, failedNode *Node, err error) {
 		}
 
 		invariantFailure, symmetryFound := p.processNode(node)
-		if p.visited[node.HashCode()] == nil && !symmetryFound {
-			p.visited[node.HashCode()] = node
+
+		if symmetryFound {
+			continue
 		}
 
 		if invariantFailure && failedNode == nil {
@@ -920,6 +921,7 @@ func (p *Processor) processNode(node *Node) (bool, bool) {
 		p.visited[hashCode] = node
 	}
 
+	p.visited[hashCode] = node
 	var failedInvariants map[int][]int
 	if yield {
 		failedInvariants = CheckInvariants(node.Process)

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -213,6 +213,8 @@ func (p *Process) Fork() *Process {
 
 	refs := make(map[string]*Role)
 	clone.SetCustomPtrFunc(reflect.TypeOf(&Role{}), roleResolveCloneFn(refs, nil, 0))
+	clone.SetCustomFunc(reflect.TypeOf(starlark.Set{}), starlarkSetResolveFn(refs, nil, 0))
+	clone.SetCustomFunc(reflect.TypeOf(starlark.Dict{}), starlarkDictResolveFn(refs, nil, 0))
 	p2 := &Process{
 		Name:        p.Name,
 		Heap:        p.Heap.Clone(refs, nil, 0),
@@ -254,6 +256,8 @@ func (p *Process) CloneForAssert(permutations map[lib.SymmetricValue][]lib.Symme
 
 	refs := make(map[string]*Role)
 	clone.SetCustomPtrFunc(reflect.TypeOf(&Role{}), roleResolveCloneFn(refs, permutations, alt))
+	clone.SetCustomFunc(reflect.TypeOf(starlark.Dict{}), starlarkDictResolveFn(refs, permutations, alt))
+	clone.SetCustomFunc(reflect.TypeOf(starlark.Set{}), starlarkSetResolveFn(refs, permutations, alt))
 	clone.SetCustomFunc(reflect.TypeOf(lib.SymmetricValue{}), symmetricValueResolveFn(refs, permutations, alt))
 	p2 := &Process{
 		Name:        p.Name,

--- a/modelchecker/thread.go
+++ b/modelchecker/thread.go
@@ -542,6 +542,7 @@ func (t *Thread) executeStatement() ([]*Process, bool) {
 		val, err := t.Process.Evaluator.EvalExpr(t.getFileName(), stmt.AnyStmt.IterExpr, vars)
 		// TODO: This source info should be for the pyExpr not the anyStmt
 		t.Process.PanicOnError(stmt.AnyStmt.GetSourceInfo(), fmt.Sprintf("Error evaluating expr: %s", stmt.AnyStmt.PyExpr), err)
+		t.Process.updateAllVariablesInScope(vars)
 		//PanicOnError(err)
 		rangeVal, _ := val.(starlark.Iterable)
 		iter := rangeVal.Iterate()

--- a/modelchecker/thread.go
+++ b/modelchecker/thread.go
@@ -771,9 +771,10 @@ func (t *Thread) executeStatement() ([]*Process, bool) {
 			newFrame := &CallFrame{FileIndex: def.fileIndex, pc: def.path + ".Block", Name: stmt.CallStmt.Name}
 			newFrame.vars = starlark.StringDict{}
 			hasNamedArgs := false
+			vars := t.Process.GetAllVariablesNocopy()
 			for i, arg := range stmt.CallStmt.Args {
 				// TODO: Is it really required to GetAllVariables() for each arg?
-				vars := t.Process.GetAllVariablesNocopy()
+
 				val, err := t.Process.Evaluator.EvalExpr(t.getFileName(), arg.Expr, vars)
 				// TODO: This source info should be for the pyExpr not the callStmt
 				t.Process.PanicOnError(arg.Expr.GetSourceInfo(), fmt.Sprintf("Error evaluating expr: %s", arg.PyExpr), err)
@@ -791,11 +792,11 @@ func (t *Thread) executeStatement() ([]*Process, bool) {
 					panic("Named arguments must come after positional arguments")
 				}
 			}
+			vars = t.Process.GetAllVariablesNocopy()
 			for _, param := range def.params {
 				// handle default values
 				if _, ok := newFrame.vars[param.Name]; !ok {
 					if param.DefaultPyExpr != "" {
-						vars := t.Process.GetAllVariablesNocopy()
 						val, err := t.Process.Evaluator.EvalExpr(t.getFileName(), param.DefaultExpr, vars)
 						t.Process.PanicOnError(param.GetDefaultExpr().GetSourceInfo(), fmt.Sprintf("Error evaluating expr: %s", param.DefaultPyExpr), err)
 						//PanicOnError(err)


### PR DESCRIPTION
1. Do not deep-clone the state after each statement. Instead, do it only once when creating a new fork.
2. Cache the hashcode to avoid expensive hash computation.
3. Added a flag --internal_profile that will enable profiling