### PR TITLE
Implement deepcopy builtin

### DIFF
--- a/modelchecker/clone.go
+++ b/modelchecker/clone.go
@@ -202,3 +202,12 @@ func deepCloneIterableToList(iterable starlark.Iterable, refs map[string]*Role, 
     }
     return newList, nil
 }
+
+
+func DeepCopyBuiltIn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+    if len(args) != 1 {
+        return nil, fmt.Errorf("expected: only a single arg, but had %d args", len(args))
+    }
+    value, err := deepCloneStarlarkValue(args[0], nil)
+    return value, err
+}

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -463,6 +463,7 @@ func (p *Process) GetAllVariables() starlark.StringDict {
 	CopyDict(frame.vars, dict, roleRefs, nil, 0)
 	frame.scope.getAllVisibleVariablesResolveRoles(dict, roleRefs)
 	maps.Copy(dict, lib.Builtins)
+	dict["deepcopy"] = starlark.NewBuiltin("deepcopy", DeepCopyBuiltIn)
 
 	for _, file := range p.Files {
 		for _, role := range file.Roles {
@@ -488,6 +489,7 @@ func (p *Process) GetAllVariablesNocopy() starlark.StringDict {
 	frame.scope.getAllVisibleVariablesToDictNoCopy(dict)
 
 	maps.Copy(dict, lib.Builtins)
+	dict["deepcopy"] = starlark.NewBuiltin("deepcopy", DeepCopyBuiltIn)
 
 	for _, file := range p.Files {
 		for _, role := range file.Roles {


### PR DESCRIPTION
Usage:

```
Color = enum('RED', 'YELLOW', 'GREEN')

action Init:
    # Define a record
    nested = record(a=1, b=[2, 3])
    msg = record(node=5, color=Color.RED, message='Hello', nested=nested)
    msg2 = msg
    msg3 = deepcopy(msg)
    print("orig", msg, msg2, msg3)

    msg.color = Color.GREEN
    msg.nested.a = -1
    msg.nested.b[0] = -2

    print("after", msg, msg2, msg3)

```

Limitations:
1. Does not handle recursive data - it will go on an infinite loop :( .
2. If two fields refer to a common data in the original, in the copy, it will be two separate data. So they are not structurally equivalent.
  ```
  action Init:
    arr = [2, 3]
    m1 = record(arr1=arr, arr2=arr)
    m2 = deepcopy(m1)
    print("orig", m1, m2)
    m1.arr1[0] = -4
    m2.arr1[0] = -3
    print("after", m1, m2)
  ```
In the original, m1.arr1 and m1.arr2 points to the same array. So changing arr1 changes arr2 as well.
But in the deepcopy, m2.arr1 and m2.arr2 DO NOT point to the same array, so changing arr1 doesn't change arr2.


