### PR TITLE
Implement simulation mode

### DIFF
--- a/fizz
+++ b/fizz
@@ -4,12 +4,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKING_DIR="$(pwd)"
 
 usage() {
-  echo "Usage: $0 [-x|--simulation] filename"
+  echo "Usage: $0 [-x|--simulation] [--seed int64Number] filename"
   exit 1
 }
 
 # Initialize variables
 simulation=false
+seed=0
 
 # Parse options
 while [[ "$1" =~ ^- ]]; do
@@ -17,6 +18,15 @@ while [[ "$1" =~ ^- ]]; do
     -x | --simulation )
       simulation=true
       shift
+      ;;
+    --seed )
+      if [[ -n "$2" ]] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        seed="$2"
+        shift 2
+      else
+        echo "Error: --seed requires a numeric value." 1>&2
+        usage
+      fi
       ;;
     --internal_profile )
       internal_profile=true
@@ -87,6 +97,10 @@ fi
 if [ "$internal_profile" = true ]; then
   args+=("--internal_profile")
 fi
+if [ "$seed" -ne 0 ]; then
+  args+=("--seed" "$seed")
+fi
+
 args+=("$json_filename")
 
 

--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "linear_collection.go",
         "permutations.go",
         "queue.go",
+        "randomqueue.go",
         "stack.go",
         "starlark_role.go",
         "starlark_types.go",

--- a/lib/linear_collection.go
+++ b/lib/linear_collection.go
@@ -5,4 +5,7 @@ type LinearCollection[T any] interface {
     Empty() bool
     Add(T)
     Remove() (T, bool)
+    Clear(n int)
+    ClearAll()
+    Retain(n int)
 }

--- a/lib/queue.go
+++ b/lib/queue.go
@@ -16,13 +16,9 @@ type Queue[T any] struct {
 
     count int
 }
-
-func (q *Queue[T]) Len() int {
-    return q.Count()
-}
-
-func (q *Queue[T]) Empty() bool {
-    return q.Empty()
+func (q *Queue[T]) Retain(n int) {
+    //TODO implement me
+    panic("Retain not implemented")
 }
 
 func (q *Queue[T]) Add(t T) {
@@ -31,6 +27,27 @@ func (q *Queue[T]) Add(t T) {
 
 func (q *Queue[T]) Remove() (T, bool) {
     return q.Dequeue()
+}
+
+func (q *Queue[T]) Clear(int) {
+    //TODO implement me
+    panic("Clear not implemented.")
+}
+
+func (q *Queue[T]) ClearAll() {
+    // Clear all elements
+    q.lock.Lock()
+    defer q.lock.Unlock()
+    q.list.Init()
+    q.count = 0
+}
+
+func (q *Queue[T]) Len() int {
+    return q.Count()
+}
+
+func (q *Queue[T]) Empty() bool {
+    return q.Empty()
 }
 
 func NewQueue[T any]() *Queue[T] {

--- a/lib/randomqueue.go
+++ b/lib/randomqueue.go
@@ -1,0 +1,74 @@
+package lib
+
+import (
+    "math/rand"
+    "sync"
+)
+
+type RandomQueue[T any] struct {
+    lock sync.Mutex // you don't have to do this if you don't want thread safety
+    arr []T
+    rand rand.Rand
+}
+
+func (r *RandomQueue[T]) Add(t T) {
+    r.lock.Lock()
+    defer r.lock.Unlock()
+    r.arr = append(r.arr, t)
+}
+
+func (r *RandomQueue[T]) Remove() (T, bool) {
+    r.lock.Lock()
+    defer r.lock.Unlock()
+    var v T
+    n := len(r.arr)
+    if n == 0 {
+        return v, false
+    }
+    // Remove a random element
+    idx := r.rand.Intn(n)
+    v = r.arr[idx]
+    r.arr = append(r.arr[:idx], r.arr[idx+1:]...)
+    return v, true
+}
+
+func (r *RandomQueue[T]) Clear(n int) {
+    // Remove the first n elements
+    r.lock.Lock()
+    defer r.lock.Unlock()
+    if n > len(r.arr) {
+        n = len(r.arr)
+    }
+    r.arr = r.arr[n:]
+}
+
+func (r *RandomQueue[T]) ClearAll() {
+    r.lock.Lock()
+    defer r.lock.Unlock()
+    r.arr = r.arr[:0]
+}
+
+
+func (r *RandomQueue[T]) Retain(n int) {
+    // Retain the first n elements and remove all others
+    r.lock.Lock()
+    defer r.lock.Unlock()
+    if n < len(r.arr) {
+        r.arr = r.arr[:n]
+    }
+}
+
+func (r *RandomQueue[T]) Len() int {
+    return len(r.arr)
+}
+
+func (r *RandomQueue[T]) Empty() bool {
+    return len(r.arr) == 0
+}
+
+func NewRandomQueue[T any](random rand.Rand) *RandomQueue[T] {
+    return &RandomQueue[T]{sync.Mutex{}, make([]T, 0), random}
+}
+
+// Ensures Queue implements LinearCollection
+var _ LinearCollection[interface{}] = (*(RandomQueue[interface{}]))(nil)

--- a/lib/stack.go
+++ b/lib/stack.go
@@ -16,8 +16,9 @@ type Stack[T any] struct {
 	head *T
 }
 
-func (s *Stack[T]) Empty() bool {
-	return s.Empty()
+func (s *Stack[T]) Retain(n int) {
+	//TODO implement me
+	panic("Retain not implemented")
 }
 
 func (s *Stack[T]) Add(t T) {
@@ -26,6 +27,20 @@ func (s *Stack[T]) Add(t T) {
 
 func (s *Stack[T]) Remove() (T, bool) {
 	return s.Pop()
+}
+
+func (s *Stack[T]) Clear(n int) {
+	//TODO implement me
+	panic("Clear not implemented.")
+}
+
+func (s *Stack[T]) ClearAll() {
+	//TODO implement me
+	panic("ClearAll not implemented.")
+}
+
+func (s *Stack[T]) Empty() bool {
+	return s.Empty()
 }
 
 func NewStack[T any]() *Stack[T] {

--- a/lib/starlark_role.go
+++ b/lib/starlark_role.go
@@ -15,6 +15,10 @@ var (
 var (
 	roleRefs = map[string]int{}
 )
+
+func ClearRoleRefs()  {
+	roleRefs = map[string]int{}
+}
 type Role struct {
 	Ref  int
 	Name string

--- a/modelchecker/invariants.go
+++ b/modelchecker/invariants.go
@@ -91,7 +91,6 @@ func CheckAssertion(process *Process, invariant *ast.Invariant, index int) bool 
 }
 
 func CheckStrictLiveness(node *Node) ([]*Link, *InvariantPosition) {
-	fmt.Println("Checking strict liveness")
 	process := node.Process
 	if len(process.Files) > 1 {
 		panic("Invariant checking not supported for multiple files yet")

--- a/modelchecker/markovchain.go
+++ b/modelchecker/markovchain.go
@@ -601,7 +601,6 @@ func traverseBFS(rootNode *Node) ([]*Node, []string, *Node, int) {
 			}
 		}
 	}
-	fmt.Println("Max Depth", maxDepth)
 	var deadlock *Node
 	for _, node := range result {
 		entry := visited[node]

--- a/modelchecker/markovchain_test.go
+++ b/modelchecker/markovchain_test.go
@@ -143,7 +143,7 @@ func TestSteadyStateDistribution(t *testing.T) {
 					},
 				}
 			}
-			p1 := NewProcessor(files, stateCfg, false, "")
+			p1 := NewProcessor(files, stateCfg, false, 0, "")
 			root, _, _ := p1.Start()
 			//RemoveMergeNodes(root)
 

--- a/modelchecker/processor_test.go
+++ b/modelchecker/processor_test.go
@@ -98,7 +98,7 @@ func TestProcessor_Start(t *testing.T) {
 		Options: &ast.Options{
 			MaxActions: 1,
 		},
-	}, false, "")
+	}, false, 0, "")
 	root, _, _ := p1.Start()
 	assert.NotNil(t, root)
 	assert.Equal(t, 91, len(p1.visited))
@@ -532,7 +532,7 @@ func TestProcessor_Tutorials(t *testing.T) {
 				}
 			}
 
-			p1 := NewProcessor(files, stateConfig, false, "")
+			p1 := NewProcessor(files, stateConfig, false, 0, "")
 			startTime := time.Now()
 			root, _, err := p1.Start()
 			require.Nil(t, err)


### PR DESCRIPTION
Implements simulation mode.
Adds flag `--simulation` and an optional seed with `--seed numeric` to reproduce the failure case.

- Runs in a single thread, but you can start multiple processes to parallelize
- Supports deadlock detection
- Liveness checks mostly work, but there are some false positives that will be fixed soon.

To run without liveness check, the cases are explored randomly until the path reaches the max_actions (default=100) and at each step checks for the safety constraints, without maintaining visited nodes or cycle detection..

With liveness enabled (that is at least one liveness assertion), the paths would be explored randomly until a max length (0, max_actions), without maintaining visited nodes or cycle detection. Once this random path length is reached, only fair actions will be scheduled going forward, and starts maintaining visited nodes to enable cycle detection.
If no fair action could be enabled, it will be considered stuttering. If a cycle is found, it will check for always eventually and eventually always property in the cycle. 

Note: If the cycle is detected, we do not check if the cycle match the fairness criteria. So this could lead to false positives with error.