### PR TITLE
fix: support running `fizz` when symlinked 

### DIFF
--- a/fizz
+++ b/fizz
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")")"
 WORKING_DIR="$(pwd)"
 
 usage() {
@@ -80,7 +80,7 @@ FIZZBEE_BIN="$SCRIPT_DIR/bazel-bin/fizzbee_/fizzbee"
 temp_output=$(mktemp)
 if ! "$PARSER_BIN" "$input_filename" > "$temp_output"; then
     echo "Error: Compilation failed"
-    echo "Logs at $temp_output" 
+    echo "Logs at $temp_output"
     exit 1
 fi
 


### PR DESCRIPTION
by resolving SCRIPT_DIR to the target of the symlink

fixes:
```
❯ fizz bank.fizz
/Users/tekumara/.local/bin/fizz: line 81: /Users/tekumara/.local/bin/bazel-bin/parser/parser_bin: No such file or directory
Error: Compilation failed
```
