### PR TITLE
Do not stutter while processing a request.

### DIFF
--- a/modelchecker/invariants.go
+++ b/modelchecker/invariants.go
@@ -611,13 +611,18 @@ func cycleFinderHelper(node *Node, callback CycleCallback, visited map[*Node]boo
 	}
 	globalVisited[node] = true
 	hasFair := false
+	pendingAction := false
 	for _, link := range node.Outbound {
 		if link.Fairness == ast.FairnessLevel_FAIRNESS_LEVEL_STRONG ||
 			link.Fairness == ast.FairnessLevel_FAIRNESS_LEVEL_WEAK {
 			hasFair = true
 		}
+		if strings.HasPrefix(link.Name, "thread-") {
+			pendingAction = true
+		}
 	}
-	if node.Name == "yield" && !hasFair {
+
+	if node.Name == "yield" && !hasFair && !pendingAction {
 		pathCopy := slices.Clone(path)
 		pathCopy = append(pathCopy, &Link{
 			Node:     node,


### PR DESCRIPTION
When an action is at a yield point, do not stutter even if it is not a fair action.

Without it, it causes issues with liveness check and it is unintuitive.  