### PR TITLE
Add platform BUILD spec for macos/windows to allow cross compilation from different host.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,6 +20,38 @@ platform(
     ],
 )
 
+platform(
+    name = "macos_x86",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "macos_arm",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform(
+    name = "windows_x86",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "windows_arm",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:arm64",
+    ],
+)
+
 go_library(
     name = "fizzbee_lib",
     srcs = ["main.go"],


### PR DESCRIPTION
This is required to be able to generate prebuilt binaries for other platforms from a single machine.

For example: To build the model checker for macos on x86

```
bazel build --platforms=//:macos_x86  //:fizzbee
bazel build --platforms=//:macos_x86  //parser/...
```

|                        | x86                 |  arm                  |
| ------------- | ------------- |----------------|
| Linux              | linux_x86      | linux_arm          |
| Mac                | macos_x86    | macos_arm      |
| Windows       | windows_x86 | windows_arm  |