### PR TITLE
Make variables funciton scoped to match python. 

### DIFF
--- a/modelchecker/graph.go
+++ b/modelchecker/graph.go
@@ -54,7 +54,7 @@ func GenerateProtoOfJson(nodes []*Node, pathPrefix string) ([]string, []string, 
         nodeJsons = nodeJsons[:0]
     }
 
-    linksShardSize := 1000000
+    linksShardSize := 10000000
     linkShards := edges / linksShardSize
 
     links := make([]*proto.Link, 0, linksShardSize)

--- a/modelchecker/thread.go
+++ b/modelchecker/thread.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"hash"
 	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -425,6 +426,7 @@ func (t *Thread) InsertNewScope() *Scope {
 	t.currentFrame().scope = scope
 	if scope.parent != nil {
 		scope.flow = scope.parent.flow
+		scope.vars = scope.parent.vars
 	}
 	return scope
 }
@@ -1181,7 +1183,7 @@ func (t *Thread) executeEndOfBlock() bool {
 					}
 					variables := oldScope.GetAllVisibleVariables(roleRefs)
 					for s, value := range variables {
-						if !t.Process.Heap.globals.Has(s) {
+						if !t.Process.Heap.globals.Has(s) && slices.Contains(t.Process.topLevelVars, s) {
 							t.Process.Heap.insert(s, value)
 						}
 					}


### PR DESCRIPTION
This simplifies a lot of code. Especially when mixing atomic blocks within serial code. Previously, variables declared within atomic blocks are not visible outside. So, we need to do a lot of workarounds. This would simplify that.

For the state variables, we still use only the top level variables within the init functiosn as state variables instead of all variables in the init
