### PR TITLE
Support DFS and random exploration strategy

### DIFF
--- a/fizz
+++ b/fizz
@@ -4,7 +4,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")")"
 WORKING_DIR="$(pwd)"
 
 usage() {
-  echo "Usage: $0 [-x|--simulation] [--seed int64Number] [-- max_runs intNumber] filename"
+  echo "Usage: $0 [-x|--simulation] [--seed int64Number] [--max_runs intNumber] [--exploration_strategy dfs] filename"
   exit 1
 }
 
@@ -12,6 +12,7 @@ usage() {
 simulation=false
 seed=0
 max_runs=0
+exploration_strategy=bfs
 
 # Parse options
 while [[ "$1" =~ ^- ]]; do
@@ -35,6 +36,15 @@ while [[ "$1" =~ ^- ]]; do
         shift 2
       else
         echo "Error: --max_runs requires a numeric value." 1>&2
+        usage
+      fi
+      ;;
+    --exploration_strategy )
+      if [[ -n "$2" ]]; then
+        exploration_strategy="$2"
+        shift 2
+      else
+        echo "Error: --exploration_strategy requires a string value one of [bfs, dfs, random]." 1>&2
         usage
       fi
       ;;
@@ -112,6 +122,9 @@ if [ "$seed" -ne 0 ]; then
 fi
 if [ "$max_runs" -ne 0 ]; then
   args+=("--max_runs" "$max_runs")
+fi
+if [ "$exploration_strategy" != "bfs" ]; then
+  args+=("--exploration_strategy" "$exploration_strategy")
 fi
 
 args+=("$json_filename")

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var internalProfile bool
 var saveStates bool
 var seed int64
 var maxRuns int
+var explorationStrategy string
 
 func main() {
 	flag.BoolVar(&isPlayground, "playground", false, "is for playground")
@@ -37,6 +38,7 @@ func main() {
 	flag.BoolVar(&saveStates, "save_states", false, "Save states to disk")
 	flag.Int64Var(&seed, "seed", 0, "Seed for random number generator used in simulation mode")
 	flag.IntVar(&maxRuns, "max_runs", 0, "Maximum number of simulation runs/paths to explore. Default=0 for unlimited")
+        flag.StringVar(&explorationStrategy, "exploration_strategy", "bfs", "Exploration strategy for exhaustive model checking. Options: bfs (default), dfs, random.")
 	flag.Parse()
 
 	args := flag.Args()
@@ -148,7 +150,7 @@ func main() {
 	for !stopped && (maxRuns <= 0 || i < maxRuns) {
 		i++
 
-		p1 = modelchecker.NewProcessor([]*ast.File{f}, stateConfig, simulation, seed, dirPath)
+		p1 = modelchecker.NewProcessor([]*ast.File{f}, stateConfig, simulation, seed, dirPath, explorationStrategy)
 		if !simulation {
 			c := make(chan os.Signal)
 			signal.Notify(c, os.Interrupt, syscall.SIGTERM)

--- a/modelchecker/markovchain_test.go
+++ b/modelchecker/markovchain_test.go
@@ -143,7 +143,7 @@ func TestSteadyStateDistribution(t *testing.T) {
 					},
 				}
 			}
-			p1 := NewProcessor(files, stateCfg, false, 0, "")
+			p1 := NewProcessor(files, stateCfg, false, 0, "", "")
 			root, _, _ := p1.Start()
 			//RemoveMergeNodes(root)
 

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -951,7 +951,7 @@ type Processor struct {
 	durabilitySpec     *DurabilitySpec
 }
 
-func NewProcessor(files []*ast.File, options *ast.StateSpaceOptions, simulation bool, seed int64, dirPath string) *Processor {
+func NewProcessor(files []*ast.File, options *ast.StateSpaceOptions, simulation bool, seed int64, dirPath string, strategy string) *Processor {
 
 	var collection lib.LinearCollection[*Node]
 	var intermediateStates lib.LinearCollection[*Node]
@@ -962,6 +962,12 @@ func NewProcessor(files []*ast.File, options *ast.StateSpaceOptions, simulation 
 	if simulation {
 		collection = lib.NewRandomQueue[*Node](random)
 		intermediateStates = lib.NewRandomQueue[*Node](random)
+        } else if strategy == "dfs" {
+                collection = lib.NewStack[*Node]()
+                intermediateStates = lib.NewQueue[*Node]()
+        } else if strategy == "random" {
+                collection = lib.NewRandomQueue[*Node](random)
+                intermediateStates = lib.NewRandomQueue[*Node](random)
 	} else {
 		collection = lib.NewQueue[*Node]()
 		intermediateStates = lib.NewQueue[*Node]()

--- a/modelchecker/processor_test.go
+++ b/modelchecker/processor_test.go
@@ -98,7 +98,7 @@ func TestProcessor_Start(t *testing.T) {
 		Options: &ast.Options{
 			MaxActions: 1,
 		},
-	}, false, 0, "")
+	}, false, 0, "", "")
 	root, _, _ := p1.Start()
 	assert.NotNil(t, root)
 	assert.Equal(t, 91, len(p1.visited))
@@ -532,7 +532,7 @@ func TestProcessor_Tutorials(t *testing.T) {
 				}
 			}
 
-			p1 := NewProcessor(files, stateConfig, false, 0, "")
+			p1 := NewProcessor(files, stateConfig, false, 0, "", "")
 			startTime := time.Now()
 			root, _, err := p1.Start()
 			require.Nil(t, err)


### PR DESCRIPTION
Default is bfs. Adds the featureflag `--exploration_strategy dfs` for dfs. (random and bfs are other supported values)