### PR TITLE
Handle circular references

### DIFF
--- a/lib/jsonmarshaller_test.go
+++ b/lib/jsonmarshaller_test.go
@@ -74,7 +74,7 @@ func TestMarshalJSONStarlarkValue(t *testing.T) {
 
     for _, tt := range tests {
         t.Run(tt.name, func(t *testing.T) {
-            got, err := MarshalJSONStarlarkValue(tt.m)
+            got, err := MarshalJSONStarlarkValue(tt.m, 0)
             assert.Nil(t, err)
             assert.Equal(t, tt.want, string(got))
         })

--- a/lib/starlarkstruct.go
+++ b/lib/starlarkstruct.go
@@ -83,6 +83,15 @@ func FromStringDict(constructor starlark.Value, d starlark.StringDict) *Struct {
     return s
 }
 
+func (s *Struct) ReplaceEntriesFromStringDict(d starlark.StringDict) {
+       values := make(entries, 0, len(d))
+       for k, v := range d {
+               values = append(values, entry{k, v})
+       }
+       sort.Sort(values)
+       s.entries = values
+}
+
 // Struct is an immutable Starlark type that maps field names to values.
 // It is not iterable and does not support len.
 //
@@ -176,7 +185,7 @@ func (s *Struct) MarshalJSON() ([]byte, error) {
         }
         buf.WriteString(fmt.Sprintf("\"%s\"", e.name))
         buf.WriteString(" : ")
-        marshalled, err := MarshalJSONStarlarkValue(e.value)
+        marshalled, err := MarshalJSONStarlarkValue(e.value, 0)
         if err != nil {
             return nil, err
         }

--- a/modelchecker/channel_message.go
+++ b/modelchecker/channel_message.go
@@ -49,7 +49,7 @@ func (cm *ChannelMessage) HashCode() string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func (cm *ChannelMessage) Clone(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) *ChannelMessage {
+func (cm *ChannelMessage) Clone(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) *ChannelMessage {
 	frame, err := cm.frame.Clone(refs, permutations, alt)
 	PanicOnError(err)
 	params := CloneDict(cm.params, refs, permutations, alt)

--- a/modelchecker/clone.go
+++ b/modelchecker/clone.go
@@ -6,11 +6,17 @@ import (
 	"go.starlark.net/starlark"
 )
 
-func deepCloneStarlarkValue(value starlark.Value, refs map[string]*lib.Role) (starlark.Value, error) {
+func deepCloneStarlarkValue(value starlark.Value, refs map[starlark.Value]starlark.Value) (starlark.Value, error) {
 	return deepCloneStarlarkValueWithPermutations(value, refs, nil, 0)
 }
 
-func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) (starlark.Value, error) {
+func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) (starlark.Value, error) {
+	if refs == nil {
+		refs = make(map[starlark.Value]starlark.Value)
+	} else if cached, ok := refs[value]; ok {
+		// Cache the new reference before recursively cloning the elements
+		return cached, nil
+	}
 	// starlark has other types as well "string.elems", "string.codepoints", "function"
 	// "builtin_function_or_method".
 	switch value.Type() {
@@ -31,22 +37,28 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 		}
 		return value, nil
 	case "list":
-		// For lists, recursively clone each element
-		iterable := value.(starlark.Iterable)
-		newList, err := deepCloneIterableToList(iterable, refs, permutations, alt)
-		if err != nil {
-			return nil, err
-		}
+		newVal := starlark.NewList(make([]starlark.Value, 0))
+		refs[value] = newVal
 
-		return starlark.NewList(newList), nil
-	case "set":
 		// For lists, recursively clone each element
 		iterable := value.(starlark.Iterable)
 		newList, err := deepCloneIterableToList(iterable, refs, permutations, alt)
 		if err != nil {
 			return nil, err
 		}
-		newSet := starlark.NewSet(len(newList))
+		for _, elem := range newList {
+			_ = newVal.Append(elem)
+		}
+		return newVal, nil
+	case "set":
+		newSet := starlark.NewSet(0)
+		refs[value] = newSet
+		// For sets, recursively clone each element
+		iterable := value.(starlark.Iterable)
+		newList, err := deepCloneIterableToList(iterable, refs, permutations, alt)
+		if err != nil {
+			return nil, err
+		}
 		for _, v := range newList {
 			err := newSet.Insert(v)
 			if err != nil {
@@ -55,13 +67,14 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 		}
 		return newSet, nil
 	case "tuple":
-		// For lists, recursively clone each element
+		newTuple := starlark.Tuple{}
+		refs[value] = newTuple
+		// For tuples, recursively clone each element
 		iterable := value.(starlark.Iterable)
 		newList, err := deepCloneIterableToList(iterable, refs, permutations, alt)
 		if err != nil {
 			return nil, err
 		}
-		newTuple := starlark.Tuple{}
 		for _, v := range newList {
 			newTuple = append(newTuple, v)
 		}
@@ -77,10 +90,14 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 	case "record":
 		v := value.(*lib.Struct)
 		dict := starlark.StringDict{}
+		newVal := lib.FromStringDict(v.Constructor(), dict)
+		refs[value] = newVal
 		v.ToStringDict(dict)
 		newDict := CloneDict(dict, refs, permutations, alt)
-		return lib.FromStringDict(v.Constructor(), newDict), nil
+		newVal.ReplaceEntriesFromStringDict(newDict)
+		return newVal, nil
 	case "RoleStub":
+		// TODO(jp): Should this also reuse cached refs?
 		r := value.(*lib.RoleStub)
 		role, err := deepCloneStarlarkValueWithPermutations(r.Role, refs, permutations, alt)
 		if err != nil {
@@ -90,6 +107,7 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 	case "genericset":
 		s := value.(*lib.GenericSet)
 		newSet := lib.NewGenericSet()
+		refs[value] = newSet
 		iter := s.Iterate()
 		defer iter.Done()
 		var x starlark.Value
@@ -105,6 +123,7 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 	case "genericmap":
 		m := value.(*lib.GenericMap)
 		newMap := lib.NewGenericMap()
+		refs[value] = newMap
 		for _, tuple := range m.Items() {
 			key, value := tuple[0], tuple[1]
 			clonedKey, err := deepCloneStarlarkValueWithPermutations(key, refs, permutations, alt)
@@ -121,6 +140,7 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 	case "bag":
 		b := value.(*lib.Bag)
 		newBag := lib.NewBag(nil)
+		refs[value] = newBag
 		iter := b.Iterate()
 		defer iter.Done()
 		var x starlark.Value
@@ -148,9 +168,7 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 			id = newRoleId.GetId()
 		}
 
-		newRefString := lib.GenerateRefString(prefix, id)
-
-		if cached, ok := refs[newRefString]; ok {
+		if cached, ok := refs[value]; ok {
 			return cached, nil
 		} else {
 			params, err := deepCloneStarlarkValueWithPermutations(r.Params, refs, permutations, alt)
@@ -171,7 +189,7 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 				RoleMethods: r.RoleMethods,
 				InitValues:  r.InitValues,
 			}
-			refs[newRole.RefString()] = newRole
+			refs[value] = newRole
 			return newRole, nil
 		}
 	default:
@@ -179,8 +197,11 @@ func deepCloneStarlarkValueWithPermutations(value starlark.Value, refs map[strin
 	}
 }
 
-func deepCloneStringDict(v *starlark.Dict, refs map[string]*lib.Role, src map[lib.SymmetricValue][]lib.SymmetricValue, alt int) (*starlark.Dict, error) {
+func deepCloneStringDict(v *starlark.Dict, refs map[starlark.Value]starlark.Value,
+	src map[lib.SymmetricValue][]lib.SymmetricValue, alt int) (*starlark.Dict, error) {
+
 	newDict := &starlark.Dict{}
+	refs[v] = newDict
 	for _, item := range v.Items() {
 		k, v := item[0], item[1]
 		clonedKey, err := deepCloneStarlarkValueWithPermutations(k, refs, src, alt)
@@ -196,7 +217,7 @@ func deepCloneStringDict(v *starlark.Dict, refs map[string]*lib.Role, src map[li
 	return newDict, nil
 }
 
-func deepCloneIterableToList(iterable starlark.Iterable, refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) ([]starlark.Value, error) {
+func deepCloneIterableToList(iterable starlark.Iterable, refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) ([]starlark.Value, error) {
 	var newList []starlark.Value
 	iter := iterable.Iterate()
 	defer iter.Done()

--- a/modelchecker/clonehelper.go
+++ b/modelchecker/clonehelper.go
@@ -82,7 +82,7 @@ func parseReflectValue(v reflect.Value) interfaceData {
 	return *(*interfaceData)(ptr)
 }
 
-func roleResolveCloneFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func roleResolveCloneFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 
 		var oldRole *lib.Role
@@ -107,7 +107,7 @@ func roleResolveCloneFn(refs map[string]*lib.Role, permutations map[lib.Symmetri
 	}
 }
 
-func symmetricValueResolveFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func symmetricValueResolveFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 		value := new.Addr().Interface().(*lib.SymmetricValue)
 		oldVal := old.Interface().(lib.SymmetricValue)
@@ -116,7 +116,7 @@ func symmetricValueResolveFn(refs map[string]*lib.Role, permutations map[lib.Sym
 	}
 }
 
-func starlarkDictResolveFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func starlarkDictResolveFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 		value := new.Addr().Interface().(*starlark.Dict)
 		oldVal := old.Addr().Interface().(*starlark.Dict)
@@ -128,7 +128,7 @@ func starlarkDictResolveFn(refs map[string]*lib.Role, permutations map[lib.Symme
 	}
 }
 
-func starlarkSetResolveFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func starlarkSetResolveFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 		value := new.Addr().Interface().(*starlark.Set)
 		oldVal := old.Addr().Interface().(*starlark.Set)

--- a/modelchecker/invariants.go
+++ b/modelchecker/invariants.go
@@ -87,7 +87,7 @@ func CheckInvariant(process *Process, invariant *ast.Invariant) bool {
 	if eventuallyAlways && invariant.Nested != nil {
 		pyExpr = invariant.Nested.PyExpr
 	}
-	ref := make(map[string]*lib.Role)
+	ref := make(map[starlark.Value]starlark.Value)
 	vars := CloneDict(process.Heap.state, ref, nil, 0)
 	vars["__returns__"] = NewDictFromStringDict(process.Returns)
 	cond, err := process.Evaluator.EvalPyExpr(process.Files[0].GetSourceInfo().GetFileName(), pyExpr, vars)

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -288,7 +288,7 @@ func (p *Process) Fork() *Process {
 	forkLock.Lock()
 	defer forkLock.Unlock()
 
-	refs := make(map[string]*lib.Role)
+	refs := make(map[starlark.Value]starlark.Value)
 	clone.SetCustomPtrFunc(reflect.TypeOf(&lib.Role{}), roleResolveCloneFn(refs, nil, 0))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Set{}), starlarkSetResolveFn(refs, nil, 0))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Dict{}), starlarkDictResolveFn(refs, nil, 0))
@@ -352,7 +352,7 @@ func (p *Process) CloneForAssert(permutations map[lib.SymmetricValue][]lib.Symme
 	forkLock.Lock()
 	defer forkLock.Unlock()
 
-	refs := make(map[string]*lib.Role)
+	refs := make(map[starlark.Value]starlark.Value)
 	clone.SetCustomPtrFunc(reflect.TypeOf(&lib.Role{}), roleResolveCloneFn(refs, permutations, alt))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Dict{}), starlarkDictResolveFn(refs, permutations, alt))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Set{}), starlarkSetResolveFn(refs, permutations, alt))
@@ -403,12 +403,12 @@ func (p *Process) CloneForAssert(permutations map[lib.SymmetricValue][]lib.Symme
 
 // MapRoleValuesInOrder returns the values of the map m.
 // The values will be in an indeterminate order.
-func MapRoleValuesInOrder(m map[string]*lib.Role, oldList []*lib.Role) []*lib.Role {
+func MapRoleValuesInOrder(m map[starlark.Value]starlark.Value, oldList []*lib.Role) []*lib.Role {
 	r := make([]*lib.Role, 0, len(m))
 	for _, v := range oldList {
 		if v != nil {
-			if role, ok := m[v.RefString()]; ok {
-				r = append(r, role)
+			if role, ok := m[v]; ok {
+				r = append(r, role.(*lib.Role))
 			}
 		}
 	}
@@ -598,9 +598,9 @@ func (p *Process) GetAllVariables() starlark.StringDict {
 	// Shallow clone the globals
 	dict := maps.Clone(p.Heap.globals)
 
-	roleRefs := make(map[string]*lib.Role)
-	for i, role := range p.Roles {
-		roleRefs[role.RefString()] = p.Roles[i]
+	roleRefs := make(map[starlark.Value]starlark.Value)
+	for _, role := range p.Roles {
+		roleRefs[role] = role
 	}
 
 	CopyDict(p.Heap.state, dict, roleRefs, nil, 0)
@@ -1329,7 +1329,7 @@ func processPreInit(init *Node, stmts []*ast.Statement) {
 			panic("Not supported: No non-determinism at top level in stmt" + stmt.String())
 		}
 	}
-	vars := thread.currentFrame().scope.GetAllVisibleVariables(nil)
+	vars := thread.currentFrame().scope.GetAllVisibleVariables(make(map[starlark.Value]starlark.Value))
 	globals := starlark.StringDict{}
 	for name, _ := range vars {
 		if slices.Contains(init.Process.topLevelVars, name) {


### PR DESCRIPTION
Handle circular references. I see two areas where this issue is present.

1. Cloning the state space whenever there is a fork. (Properly handled)
2. Dumping data as JSON (A quick hack to prevent infinite recursion by limiting max depth)

#183 