### PR TITLE
Handle circular references (#186)

### DIFF
--- a/lib/jsonmarshaller_test.go
+++ b/lib/jsonmarshaller_test.go
@@ -74,7 +74,7 @@ func TestMarshalJSONStarlarkValue(t *testing.T) {
 
     for _, tt := range tests {
         t.Run(tt.name, func(t *testing.T) {
-            got, err := MarshalJSONStarlarkValue(tt.m)
+            got, err := MarshalJSONStarlarkValue(tt.m, 0)
             assert.Nil(t, err)
             assert.Equal(t, tt.want, string(got))
         })

--- a/lib/starlarkstruct.go
+++ b/lib/starlarkstruct.go
@@ -83,6 +83,15 @@ func FromStringDict(constructor starlark.Value, d starlark.StringDict) *Struct {
     return s
 }
 
+func (s *Struct) ReplaceEntriesFromStringDict(d starlark.StringDict) {
+       values := make(entries, 0, len(d))
+       for k, v := range d {
+               values = append(values, entry{k, v})
+       }
+       sort.Sort(values)
+       s.entries = values
+}
+
 // Struct is an immutable Starlark type that maps field names to values.
 // It is not iterable and does not support len.
 //
@@ -176,7 +185,7 @@ func (s *Struct) MarshalJSON() ([]byte, error) {
         }
         buf.WriteString(fmt.Sprintf("\"%s\"", e.name))
         buf.WriteString(" : ")
-        marshalled, err := MarshalJSONStarlarkValue(e.value)
+        marshalled, err := MarshalJSONStarlarkValue(e.value, 0)
         if err != nil {
             return nil, err
         }

--- a/modelchecker/channel_message.go
+++ b/modelchecker/channel_message.go
@@ -49,7 +49,7 @@ func (cm *ChannelMessage) HashCode() string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func (cm *ChannelMessage) Clone(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) *ChannelMessage {
+func (cm *ChannelMessage) Clone(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) *ChannelMessage {
 	frame, err := cm.frame.Clone(refs, permutations, alt)
 	PanicOnError(err)
 	params := CloneDict(cm.params, refs, permutations, alt)

--- a/modelchecker/clonehelper.go
+++ b/modelchecker/clonehelper.go
@@ -82,7 +82,7 @@ func parseReflectValue(v reflect.Value) interfaceData {
 	return *(*interfaceData)(ptr)
 }
 
-func roleResolveCloneFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func roleResolveCloneFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 
 		var oldRole *lib.Role
@@ -107,7 +107,7 @@ func roleResolveCloneFn(refs map[string]*lib.Role, permutations map[lib.Symmetri
 	}
 }
 
-func symmetricValueResolveFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func symmetricValueResolveFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 		value := new.Addr().Interface().(*lib.SymmetricValue)
 		oldVal := old.Interface().(lib.SymmetricValue)
@@ -116,7 +116,7 @@ func symmetricValueResolveFn(refs map[string]*lib.Role, permutations map[lib.Sym
 	}
 }
 
-func starlarkDictResolveFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func starlarkDictResolveFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 		value := new.Addr().Interface().(*starlark.Dict)
 		oldVal := old.Addr().Interface().(*starlark.Dict)
@@ -128,7 +128,7 @@ func starlarkDictResolveFn(refs map[string]*lib.Role, permutations map[lib.Symme
 	}
 }
 
-func starlarkSetResolveFn(refs map[string]*lib.Role, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
+func starlarkSetResolveFn(refs map[starlark.Value]starlark.Value, permutations map[lib.SymmetricValue][]lib.SymmetricValue, alt int) func(allocator *clone.Allocator, old reflect.Value, new reflect.Value) {
 	return func(allocator *clone.Allocator, old, new reflect.Value) {
 		value := new.Addr().Interface().(*starlark.Set)
 		oldVal := old.Addr().Interface().(*starlark.Set)

--- a/modelchecker/invariants.go
+++ b/modelchecker/invariants.go
@@ -87,7 +87,7 @@ func CheckInvariant(process *Process, invariant *ast.Invariant) bool {
 	if eventuallyAlways && invariant.Nested != nil {
 		pyExpr = invariant.Nested.PyExpr
 	}
-	ref := make(map[string]*lib.Role)
+	ref := make(map[starlark.Value]starlark.Value)
 	vars := CloneDict(process.Heap.state, ref, nil, 0)
 	vars["__returns__"] = NewDictFromStringDict(process.Returns)
 	cond, err := process.Evaluator.EvalPyExpr(process.Files[0].GetSourceInfo().GetFileName(), pyExpr, vars)

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -288,7 +288,7 @@ func (p *Process) Fork() *Process {
 	forkLock.Lock()
 	defer forkLock.Unlock()
 
-	refs := make(map[string]*lib.Role)
+	refs := make(map[starlark.Value]starlark.Value)
 	clone.SetCustomPtrFunc(reflect.TypeOf(&lib.Role{}), roleResolveCloneFn(refs, nil, 0))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Set{}), starlarkSetResolveFn(refs, nil, 0))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Dict{}), starlarkDictResolveFn(refs, nil, 0))
@@ -352,7 +352,7 @@ func (p *Process) CloneForAssert(permutations map[lib.SymmetricValue][]lib.Symme
 	forkLock.Lock()
 	defer forkLock.Unlock()
 
-	refs := make(map[string]*lib.Role)
+	refs := make(map[starlark.Value]starlark.Value)
 	clone.SetCustomPtrFunc(reflect.TypeOf(&lib.Role{}), roleResolveCloneFn(refs, permutations, alt))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Dict{}), starlarkDictResolveFn(refs, permutations, alt))
 	clone.SetCustomFunc(reflect.TypeOf(starlark.Set{}), starlarkSetResolveFn(refs, permutations, alt))
@@ -403,12 +403,12 @@ func (p *Process) CloneForAssert(permutations map[lib.SymmetricValue][]lib.Symme
 
 // MapRoleValuesInOrder returns the values of the map m.
 // The values will be in an indeterminate order.
-func MapRoleValuesInOrder(m map[string]*lib.Role, oldList []*lib.Role) []*lib.Role {
+func MapRoleValuesInOrder(m map[starlark.Value]starlark.Value, oldList []*lib.Role) []*lib.Role {
 	r := make([]*lib.Role, 0, len(m))
 	for _, v := range oldList {
 		if v != nil {
-			if role, ok := m[v.RefString()]; ok {
-				r = append(r, role)
+			if role, ok := m[v]; ok {
+				r = append(r, role.(*lib.Role))
 			}
 		}
 	}
@@ -598,9 +598,9 @@ func (p *Process) GetAllVariables() starlark.StringDict {
 	// Shallow clone the globals
 	dict := maps.Clone(p.Heap.globals)
 
-	roleRefs := make(map[string]*lib.Role)
-	for i, role := range p.Roles {
-		roleRefs[role.RefString()] = p.Roles[i]
+	roleRefs := make(map[starlark.Value]starlark.Value)
+	for _, role := range p.Roles {
+		roleRefs[role] = role
 	}
 
 	CopyDict(p.Heap.state, dict, roleRefs, nil, 0)
@@ -1329,7 +1329,7 @@ func processPreInit(init *Node, stmts []*ast.Statement) {
 			panic("Not supported: No non-determinism at top level in stmt" + stmt.String())
 		}
 	}
-	vars := thread.currentFrame().scope.GetAllVisibleVariables(nil)
+	vars := thread.currentFrame().scope.GetAllVisibleVariables(make(map[starlark.Value]starlark.Value))
 	globals := starlark.StringDict{}
 	for name, _ := range vars {
 		if slices.Contains(init.Process.topLevelVars, name) {


### PR DESCRIPTION
This reverts the previous revert https://github.com/fizzbee-io/fizzbee/pull/187

With the fix. Only the pointer types will be cached