### PR TITLE
Update current pc when executing any statement syntactic sugar

### DIFF
--- a/modelchecker/thread.go
+++ b/modelchecker/thread.go
@@ -714,6 +714,8 @@ func (t *Thread) executeStatement() ([]*Process, bool) {
 		if len(forks) > 0 {
 			if stmt.AnyStmt.Block == nil {
 				t.Process.Enable()
+				// This is required to ensure this step doesn't get deduplicated with the previous yield point
+				t.currentFrame().pc = t.currentFrame().pc + ".any"
 			}
 			return forks, false
 		} else if stmt.AnyStmt.Block != nil {


### PR DESCRIPTION
When the `x = any list_of_values` is evaluated, it would create one fork for each element in the list, but if the `pc` was not updated, the system thinks, it is at the same stage as before it was evaluated. This being a duplicate step, it forms a self loop.
This was not an issue with the any with the nested block syntax or the oneof statements as they update the pc to go within the block

```

action Init:
  value = False


fair action Add:
    x = 12    
    value = fair any [False, True]   


always eventually assertion BecomeTrue:
    return value

exists assertion ReachTrue:
    return value
```