### PR TITLE
Add a flag to remove timing related info from output, in preparation for testing

### DIFF
--- a/fizz
+++ b/fizz
@@ -13,7 +13,7 @@ if [[ -f $SCRIPT_ENV_FILE ]]; then
 fi
 
 usage() {
-  echo "Usage: $0 [-x|--simulation] [--seed int64Number] [--max_runs intNumber] [--exploration_strategy dfs] filename"
+  echo "Usage: $0 [-x|--simulation] [--test] [--seed int64Number] [--max_runs intNumber] [--exploration_strategy dfs] filename"
   exit 1
 }
 
@@ -22,12 +22,17 @@ simulation=false
 seed=0
 max_runs=0
 exploration_strategy=bfs
+test=false
 
 # Parse options
 while [[ "$1" =~ ^- ]]; do
   case $1 in
     -x | --simulation )
       simulation=true
+      shift
+      ;;
+    --test )
+      test=true
       shift
       ;;
     --seed )
@@ -107,6 +112,9 @@ echo "Model checking" $json_filename
 args=()
 if [ "$simulation" = true ]; then
   args+=("--simulation")
+fi
+if [ "$test" = true ]; then
+  args+=("--test")
 fi
 if [ "$internal_profile" = true ]; then
   args+=("--internal_profile")

--- a/modelchecker/markovchain_test.go
+++ b/modelchecker/markovchain_test.go
@@ -143,7 +143,7 @@ func TestSteadyStateDistribution(t *testing.T) {
 					},
 				}
 			}
-			p1 := NewProcessor(files, stateCfg, false, 0, "", "")
+			p1 := NewProcessor(files, stateCfg, false, 0, "", "", false)
 			root, _, _ := p1.Start()
 			//RemoveMergeNodes(root)
 

--- a/modelchecker/processor_test.go
+++ b/modelchecker/processor_test.go
@@ -98,7 +98,7 @@ func TestProcessor_Start(t *testing.T) {
 		Options: &ast.Options{
 			MaxActions: 1,
 		},
-	}, false, 0, "", "")
+	}, false, 0, "", "", false)
 	root, _, _ := p1.Start()
 	assert.NotNil(t, root)
 	assert.Equal(t, 91, len(p1.visited))
@@ -532,7 +532,7 @@ func TestProcessor_Tutorials(t *testing.T) {
 				}
 			}
 
-			p1 := NewProcessor(files, stateConfig, false, 0, "", "")
+			p1 := NewProcessor(files, stateConfig, false, 0, "", "", false)
 			startTime := time.Now()
 			root, _, err := p1.Start()
 			require.Nil(t, err)


### PR DESCRIPTION
We would go with end-to-end tests.
The plan is,
Have many examples, and simply compare the stdout and stderr.

We could later add mutations, and variants from the base cases later.

We would only compare the stdout/stderr of the model checker, not generated files the the ast json, graphs or other data for now.