### PR TITLE
Implement modular refinement

### DIFF
--- a/modelchecker/BUILD.bazel
+++ b/modelchecker/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "checker.go",
         "clone.go",
         "clonehelper.go",
+        "composition_types.go",
         "durability.go",
         "error.go",
         "graph.go",

--- a/modelchecker/composition_types.go
+++ b/modelchecker/composition_types.go
@@ -1,0 +1,11 @@
+package modelchecker
+
+import "github.com/fizzbee-io/fizzbee/lib"
+
+type HashKey string
+
+type Transition = lib.Pair[*Node, *Node]
+
+// type NodeSet map[*modelchecker.Node]bool
+type TransitionSet map[Transition]bool
+type JoinHashes map[HashKey][]TransitionSet

--- a/modelchecker/markovchain_test.go
+++ b/modelchecker/markovchain_test.go
@@ -143,7 +143,7 @@ func TestSteadyStateDistribution(t *testing.T) {
 					},
 				}
 			}
-			p1 := NewProcessor(files, stateCfg, false, 0, "", "", false)
+			p1 := NewProcessor(files, stateCfg, false, 0, "", "", false, nil)
 			root, _, _ := p1.Start()
 			//RemoveMergeNodes(root)
 

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -983,9 +983,10 @@ type Processor struct {
 	Seed               int64
 	durabilitySpec     *DurabilitySpec
 	isTest             bool
+	hashes             JoinHashes
 }
 
-func NewProcessor(files []*ast.File, options *ast.StateSpaceOptions, simulation bool, seed int64, dirPath string, strategy string, test bool) *Processor {
+func NewProcessor(files []*ast.File, options *ast.StateSpaceOptions, simulation bool, seed int64, dirPath string, strategy string, test bool, hashes JoinHashes) *Processor {
 
 	var collection lib.LinearCollection[*Node]
 	var intermediateStates lib.LinearCollection[*Node]
@@ -1030,6 +1031,7 @@ func NewProcessor(files []*ast.File, options *ast.StateSpaceOptions, simulation 
 		Seed:               seed,
 
 		isTest: test,
+		hashes: hashes,
 	}
 }
 
@@ -1419,6 +1421,12 @@ func (p *Processor) processNode(node *Node) (bool, bool) {
 				}
 				node.Attach()
 				p.intermediateStates.ClearAll()
+				return true, false
+			}
+		}
+		if len(node.Process.Files[0].Refinements) > 0 {
+			result := CheckRefinement(node.Process, p.Files[0].Refinements[0], p.hashes)
+			if !result {
 				return true, false
 			}
 		}

--- a/modelchecker/processor_test.go
+++ b/modelchecker/processor_test.go
@@ -98,7 +98,7 @@ func TestProcessor_Start(t *testing.T) {
 		Options: &ast.Options{
 			MaxActions: 1,
 		},
-	}, false, 0, "", "", false)
+	}, false, 0, "", "", false, nil)
 	root, _, _ := p1.Start()
 	assert.NotNil(t, root)
 	assert.Equal(t, 91, len(p1.visited))
@@ -532,7 +532,7 @@ func TestProcessor_Tutorials(t *testing.T) {
 				}
 			}
 
-			p1 := NewProcessor(files, stateConfig, false, 0, "", "", false)
+			p1 := NewProcessor(files, stateConfig, false, 0, "", "", false, nil)
 			startTime := time.Now()
 			root, _, err := p1.Start()
 			require.Nil(t, err)


### PR DESCRIPTION
- At present supports only a single refinement spec per file.
- Returns the shortest trace where the refined spec diverges from the abstract spec.
- Show the error trace in the refined spec.
- Not much of error handling or error trace display. 