### PR TITLE
Resolve role built-in function

### DIFF
--- a/lib/starlark_role.go
+++ b/lib/starlark_role.go
@@ -191,3 +191,24 @@ func fizz_func_always_error(_ *starlark.Thread, b *starlark.Builtin, args starla
 
 	return starlark.None, fmt.Errorf("%s: %v", b.Name(), "Currently, fizz functions can be called only in the following ways. \n See https://fizzbee.io/tutorials/limitations/#fizz-functions-can-be-called-only-in-a-limited-ways for more details and workaround.")
 }
+
+// CreateResolveRoleBuiltIn returns a builtin resolve_role, when called with a role's __id__ (GetId()), returns
+// the Role object in the roles array with the given id.
+func CreateResolveRoleBuiltIn(roles *[]*Role) *starlark.Builtin {
+	return starlark.NewBuiltin("resolve_role", func(t *starlark.Thread, b *starlark.Builtin,
+		args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		if len(args) != 1 {
+			return nil, fmt.Errorf("resolve_role expects exactly one argument")
+		}
+		idValue := args[0]
+		if idValue.Type() != ModelValueType && idValue.Type() != SymmetricValueType {
+			return nil, fmt.Errorf("resolve_role expects a ModelValue or SymmetricValue, got %s", idValue.Type())
+		}
+		for _, role := range *roles {
+			if role.GetId().String() == idValue.String() {
+				return role, nil
+			}
+		}
+		return nil, fmt.Errorf("role with id %d not found", idValue)
+	})
+}

--- a/lib/starlark_types.go
+++ b/lib/starlark_types.go
@@ -1197,6 +1197,8 @@ func NewModelValue(prefix string, i int) ModelValue {
 	}
 }
 
+const ModelValueType = "model_value"
+
 type ModelValue struct {
 	prefix string
 	id     int
@@ -1243,7 +1245,7 @@ func (m ModelValue) MarshalJSON() ([]byte, error) {
 }
 
 func (m ModelValue) Type() string {
-	return "model_value"
+	return ModelValueType
 }
 
 func (m ModelValue) Freeze() {}
@@ -1263,6 +1265,8 @@ func NewSymmetricValue(prefix string, i int) SymmetricValue {
 	return SymmetricValue{ModelValue{prefix: prefix, id: i}}
 }
 
+const SymmetricValueType = "symmetric_value"
+
 type SymmetricValue struct {
 	ModelValue
 }
@@ -1280,7 +1284,7 @@ func (s SymmetricValue) CompareSameType(op syntax.Token, y_ starlark.Value, dept
 }
 
 func (s SymmetricValue) Type() string {
-	return "symmetric_value"
+	return SymmetricValueType
 }
 
 var _ starlark.Value = SymmetricValue{}

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -629,6 +629,7 @@ func (p *Process) GetAllVariables() starlark.StringDict {
 	frame.scope.getAllVisibleVariablesResolveRoles(dict, roleRefs)
 	maps.Copy(dict, lib.Builtins)
 	dict["deepcopy"] = starlark.NewBuiltin("deepcopy", DeepCopyBuiltIn)
+	dict["resolve_role"] = lib.CreateResolveRoleBuiltIn(&p.Roles)
 	maps.Copy(dict, p.Modules)
 
 	for _, file := range p.Files {
@@ -657,6 +658,7 @@ func (p *Process) GetAllVariablesNocopy() starlark.StringDict {
 
 	maps.Copy(dict, lib.Builtins)
 	dict["deepcopy"] = starlark.NewBuiltin("deepcopy", DeepCopyBuiltIn)
+	dict["resolve_role"] = lib.CreateResolveRoleBuiltIn(&p.Roles)
 	maps.Copy(dict, p.Modules)
 
 	for _, file := range p.Files {


### PR DESCRIPTION
when you have a role 's id, the resolve_role can be used to find the actual role.

```
role Node:
    pass
  
action Init:
    node = Node()
    id = node.__id__
    same_node = resolve_role(id) # same as node
```
  