### PR TITLE
Add symmetry module API reference examples and documentation

### DIFF
--- a/examples/references/16-01-symmetric-values/SymmetricValues.fizz
+++ b/examples/references/16-01-symmetric-values/SymmetricValues.fizz
@@ -1,6 +1,11 @@
 # Example 0084: Symmetric Values for IDs
 # Using symmetric_values() to reduce state space by treating permutations as equivalent
 # Demonstrates: symmetric_values(), state space optimization, interchangeable IDs
+#
+# NOTE: Prefer the symmetry module API for new models. This is equivalent to:
+#   KEYS = symmetry.nominal(name="k", limit=3, materialize=True).values()
+# The symmetry module offers more types (ordinal, interval, rotational)
+# and features (reflection, divergence, segments). See 16-05 through 16-12.
 
 # Define symmetric values instead of regular numbers or strings
 # symmetric_values('prefix', count) creates prefix0, prefix1, prefix2, ...

--- a/examples/references/16-05-nominal-symmetry/NominalSymmetry.fizz
+++ b/examples/references/16-05-nominal-symmetry/NominalSymmetry.fizz
@@ -1,0 +1,30 @@
+# Nominal Symmetry: Unordered, interchangeable identifiers.
+# Operations: == and != only. No ordering, no arithmetic.
+# Reduction: permutations of active set are equivalent.
+# Use cases: user IDs, session tokens, cache keys.
+#
+# Key methods:
+#   fresh()   - allocate a new unique value (deterministic, canonical)
+#   values()  - list all active values
+#   choices() - values() + one fresh (if limit allows)
+#   choose()  - deterministic default value (like TLA+ CHOOSE); for initial values
+
+IDS = symmetry.nominal(name="id", limit=3)
+
+action Init:
+    cache = {}
+
+atomic action Put:
+    # choices() returns existing IDs + one fresh ID (if under limit).
+    # Use with `any` for nondeterministic selection.
+    id = any IDS.choices()
+    cache[id] = "data"
+
+atomic action Evict:
+    # `any` on an empty list disables the transition, so no guard needed.
+    id = any IDS.values()
+    if id in cache:
+        cache.pop(id)
+
+always assertion BoundedSize:
+    return len(cache) <= 3

--- a/examples/references/16-06-ordinal-symmetry/OrdinalSymmetry.fizz
+++ b/examples/references/16-06-ordinal-symmetry/OrdinalSymmetry.fizz
@@ -1,0 +1,37 @@
+# Ordinal Symmetry: Ordered values where only relative rank matters.
+# Operations: ==, !=, <, <=, >, >=. No arithmetic.
+# Reduction: values are squeezed to dense ranks (0,1,2,...).
+# Use cases: logical timestamps, priority levels, version numbers.
+#
+# Key methods:
+#   fresh()  - allocate value greater than all existing (appends to end)
+#   min()    - smallest active value (or fresh if empty)
+#   max()    - largest active value (or fresh if empty)
+#   values() - all active values, sorted ascending
+#
+# The model checker treats states with the same relative ordering
+# as equivalent. E.g., timestamps {10,20,30} and {1,5,99} are
+# equivalent because both have the same rank order.
+
+TIMES = symmetry.ordinal(name="ts", limit=4)
+
+action Init:
+    events = []
+
+atomic action RecordEvent:
+    # fresh() appends after max; min()/max() return the extremes.
+    t = TIMES.fresh()
+    events = events + [t]
+
+atomic action ProcessEvent:
+    # Consuming the oldest event frees a slot, allowing fresh()
+    # to allocate again -- enabling infinite traces without deadlock.
+    require len(events) > 0
+    events = events[1:]
+
+always assertion EventsOrdered:
+    # fresh() always appends, so events are in order
+    for i in range(len(events) - 1):
+        if not (events[i] < events[i + 1]):
+            return False
+    return True

--- a/examples/references/16-07-ordinal-segments/OrdinalSegments.fizz
+++ b/examples/references/16-07-ordinal-segments/OrdinalSegments.fizz
@@ -1,0 +1,44 @@
+# Ordinal Segments: Inserting values between existing ordinal values.
+# segments() returns gap objects between active values. Each gap
+# has a fresh() method to allocate a value within that gap.
+#
+# With 2 values [a, b], segments() returns 3 gaps:
+#   (-inf, a)  -- head: values less than a
+#   (a, b)     -- body: values between a and b
+#   (b, +inf)  -- tail: values greater than b
+#
+# Filtering: segments(after=v) excludes gaps before v.
+#            segments(before=v) excludes gaps after v.
+#
+# Use cases: inserting events in a timeline, priority insertion.
+
+TIMES = symmetry.ordinal(name="ts", limit=6)
+
+action Init:
+    t_start = TIMES.fresh()
+    t_end = TIMES.fresh()
+
+atomic action InsertAnywhere:
+    # Get all gaps between existing timestamps
+    gaps = TIMES.segments()
+    gap = any gaps
+    t = gap.fresh()
+
+atomic action InsertBetween:
+    # Insert strictly between t_start and t_end.
+    # Ordinal gaps are always non-empty (the domain is dense).
+    gaps = TIMES.segments(after=t_start, before=t_end)
+    gap = any gaps
+    t = gap.fresh()
+    # Guaranteed: t_start < t < t_end
+
+atomic action InsertBeforeEarliest:
+    # Insert before the minimum existing value.
+    # (Inserting after max is just fresh(), but before min needs segments.)
+    earliest = TIMES.min()
+    gaps = TIMES.segments(before=earliest)
+    gap = any gaps
+    t = gap.fresh()
+
+# Note: domain methods like values() cannot be called from assertions
+# (no symmetry context in invariant scope). Use stored state instead.

--- a/examples/references/16-08-interval-symmetry/IntervalSymmetry.fizz
+++ b/examples/references/16-08-interval-symmetry/IntervalSymmetry.fizz
@@ -1,0 +1,37 @@
+# Interval Symmetry: Ordered values where distance is meaningful.
+# Operations: ==, !=, <, <=, >, >=, +int, -int, val-val.
+# Reduction: zero-shifting (subtract minimum to normalize).
+# Use cases: sequence numbers, log indices, counters.
+#
+# Key differences from ordinal:
+#   - Supports arithmetic: val + 1, val - 1
+#   - Value difference: val1 - val2 returns a plain int
+#   - fresh() allocates max+1 (pessimistic, sequential)
+#   - `divergence` parameter bounds the max spread (max - min)
+#
+# Key methods:
+#   fresh()  - allocate max+1 (or start value if empty)
+#   min()    - smallest active value (or fresh if empty)
+#   max()    - largest active value (or fresh if empty)
+#   values() - all active values, sorted ascending
+#
+# The model checker normalizes by shifting min to 0.
+# E.g., {5,7,8} and {0,2,3} are equivalent (same distances).
+
+LIMIT = 6
+TICKS = symmetry.interval(name="t", limit=LIMIT)
+
+action Init:
+    t1 = TICKS.min()
+    t2 = TICKS.min()
+
+atomic fair action Tick1:
+    t1 = t1 + 1
+
+atomic fair action Tick2:
+    t2 = t2 + 1
+
+# With interval symmetry, only the *distances* between t1 and t2
+# matter. States {t1=0,t2=0}, {t1=5,t2=5}, {t1=100,t2=100}
+# are all equivalent (distance = 0).
+# Total unique states: O(LIMIT^2) instead of unbounded.

--- a/examples/references/16-09-interval-divergence/IntervalDivergence.fizz
+++ b/examples/references/16-09-interval-divergence/IntervalDivergence.fizz
@@ -1,0 +1,37 @@
+# Interval Divergence: Bounding the spread of interval values.
+#
+# The `divergence` parameter limits (max - min) across all active
+# values in the domain. This prevents unbounded state growth.
+#
+# Parameter rules:
+#   - divergence only:  limit = divergence + 1 (auto-derived)
+#   - limit only:       divergence = limit - 1 (auto-derived)
+#   - both:             must satisfy limit <= divergence + 1
+#   - at least one of divergence or limit is required
+#
+# When a fresh() or arithmetic would exceed the divergence bound,
+# the transition is disabled (pruned from state space).
+#
+# Use case: modeling sliding windows where values can't drift
+# too far apart (e.g., TCP window, Raft log gap).
+
+# divergence=3 means max - min <= 3 at all times.
+# limit is auto-derived to 4 (divergence + 1).
+SEQ = symmetry.interval(name="s", divergence=3)
+
+action Init:
+    head = SEQ.fresh()     # s0
+    tail = SEQ.fresh()     # s1
+
+atomic fair action AdvanceHead:
+    head = head + 1
+    # If head - tail > 3, this transition is pruned.
+
+atomic fair action AdvanceTail:
+    require tail < head
+    tail = tail + 1
+
+# Note: domain methods (values(), max(), min()) cannot be called
+# from assertions. The divergence bound is enforced automatically
+# by the symmetry engine — transitions that would violate it
+# are pruned from the state space.

--- a/examples/references/16-10-rotational-symmetry/RotationalSymmetry.fizz
+++ b/examples/references/16-10-rotational-symmetry/RotationalSymmetry.fizz
@@ -1,0 +1,40 @@
+# Rotational Symmetry: Integers mod N (ring positions).
+# Operations: ==, !=, +int, -int, val-val (all mod limit).
+# No ordering (<, >, etc.) since the domain wraps around.
+# Reduction: rotate all values to lexicographically smallest set.
+# Use cases: ring topologies, clock arithmetic, hash ring slots.
+#
+# Key methods:
+#   fresh()   - next unused position (sequential, wrapping)
+#   values()  - all active values
+#   choices() - values() + one fresh (if under limit)
+#   choose()  - min active value (or fresh if empty)
+#
+# Arithmetic wraps: on a ring of size 5, position 4 + 1 = 0.
+# Difference returns plain int: (a - b) % limit.
+#
+# With rotational symmetry, the model checker recognizes that
+# {0,2} and {1,3} and {3,0} are all equivalent (same gap pattern).
+
+RING = symmetry.rotational(name="pos", limit=5)
+
+action Init:
+    positions = set()
+
+atomic action Place:
+    require len(positions) < 3
+    p = RING.fresh()
+    positions.add(p)
+
+atomic action Advance:
+    require len(positions) > 0
+    p = any positions
+    next_p = p + 1   # wraps mod 5
+    if next_p not in positions:
+        positions.remove(p)
+        positions.add(next_p)
+
+atomic action ComputeGap:
+    require len(positions) == 2
+    pair = RING.values()
+    gap = pair[1] - pair[0]  # plain int, mod 5

--- a/examples/references/16-11-reflection/ReflectionInterval.fizz
+++ b/examples/references/16-11-reflection/ReflectionInterval.fizz
@@ -1,0 +1,28 @@
+# Reflection Symmetry (Interval): Mirror states are equivalent.
+#
+# With reflection=True, the model checker also considers the
+# "mirror image" of each state. For interval symmetry, this means
+# {a, b} with distances [0, d] is equivalent to [d, 0] (reversed).
+#
+# Concretely: state (t1=0, t2=3) is equivalent to (t1=3, t2=0)
+# because reflecting maps v -> (max - v), turning {0,3} into {3,0}
+# which normalizes back to {0,3} with swapped variable bindings.
+#
+# This is useful when two processes are truly interchangeable and
+# "t1 ahead of t2 by 3" is equivalent to "t2 ahead of t1 by 3".
+#
+# Compare: Run this file vs IntervalNoReflection.fizz to see
+# the state space reduction from reflection.
+
+LIMIT = 6
+TICKS = symmetry.interval(name="t", limit=LIMIT, reflection=True)
+
+action Init:
+    t1 = TICKS.min()
+    t2 = TICKS.min()
+
+atomic fair action Tick1:
+    t1 = t1 + 1
+
+atomic fair action Tick2:
+    t2 = t2 + 1

--- a/examples/references/16-11-reflection/ReflectionNoReflection.fizz
+++ b/examples/references/16-11-reflection/ReflectionNoReflection.fizz
@@ -1,0 +1,15 @@
+# Interval WITHOUT reflection (for comparison with ReflectionInterval.fizz).
+# Run both and compare state/node counts to see the reduction.
+
+LIMIT = 6
+TICKS = symmetry.interval(name="t", limit=LIMIT, reflection=False)
+
+action Init:
+    t1 = TICKS.min()
+    t2 = TICKS.min()
+
+atomic fair action Tick1:
+    t1 = t1 + 1
+
+atomic fair action Tick2:
+    t2 = t2 + 1

--- a/examples/references/16-11-reflection/ReflectionRotational.fizz
+++ b/examples/references/16-11-reflection/ReflectionRotational.fizz
@@ -1,0 +1,30 @@
+# Reflection Symmetry (Rotational): Clockwise = counterclockwise.
+#
+# With reflection=True on a rotational domain, the model checker
+# treats clockwise and counterclockwise orientations as equivalent.
+# On a ring of size 6: {0,1} (gap=1) and {0,5} (gap=5, i.e. -1)
+# are equivalent because one is the mirror of the other.
+#
+# Without reflection: {0,1} and {0,5} are distinct states.
+# With reflection: they collapse to one canonical state.
+#
+# Use case: undirected ring networks where message direction
+# doesn't matter, or symmetric physical arrangements.
+
+RING = symmetry.rotational(name="pos", limit=6, reflection=True)
+
+action Init:
+    positions = set()
+
+atomic action Place:
+    require len(positions) < 3
+    p = RING.fresh()
+    positions.add(p)
+
+atomic action Step:
+    require len(positions) > 0
+    p = any positions
+    next_p = p + 1
+    if next_p not in positions:
+        positions.remove(p)
+        positions.add(next_p)

--- a/examples/references/16-12-materialize/Materialize.fizz
+++ b/examples/references/16-12-materialize/Materialize.fizz
@@ -1,0 +1,40 @@
+# Materialize: Pre-populate all domain values at declaration.
+#
+# With materialize=True, all `limit` values exist from the start.
+# - values() immediately returns all values
+# - fresh() is NOT allowed (raises error)
+# - Useful when the set of values is fixed and known upfront
+#
+# Works with all symmetry types:
+#   nominal:    values 0, 1, ..., limit-1
+#   ordinal:    values 0, 1, ..., limit-1
+#   interval:   values start, start+1, ..., start+limit-1
+#   rotational: values 0, 1, ..., limit-1
+#
+# Use cases: fixed-size process rings, known node sets,
+#            enumerated configurations.
+
+NODES = symmetry.rotational(name="n", limit=4, materialize=True)
+
+action Init:
+    # All 4 values exist immediately
+    status = {}
+    for n in NODES.values():
+        status[n] = "idle"
+
+atomic action Activate:
+    n = any NODES.values()
+    require status[n] == "idle"
+    status[n] = "active"
+
+atomic action Deactivate:
+    n = any NODES.values()
+    require status[n] == "active"
+    status[n] = "idle"
+
+atomic action PassToken:
+    n = any NODES.values()
+    require status[n] == "active"
+    next_n = n + 1  # wraps mod 4
+    status[n] = "idle"
+    status[next_n] = "active"

--- a/examples/references/README.md
+++ b/examples/references/README.md
@@ -36,10 +36,10 @@ Examples use **hierarchical numbering** (e.g., `01-01`, `13-02-01`, `99-01`):
   - **13-07**: Data/Events (2) - WAL, event sourcing
 - **14**: Fault Injection (4) - Crash and message loss
 - **15**: Configuration (2) - Action-level config, coordination
-- **16**: Symmetry Reduction (4) - State space optimization
+- **16**: Symmetry Reduction (12) - State space optimization (old API + symmetry module)
 - **99**: Miscellaneous (1) - Checkpoints and other utilities
 
-**Total: 88 examples across 17 sections**
+**Total: 98 examples across 17 sections**
 
 ## Examples Created
 
@@ -576,6 +576,55 @@ Examples use **hierarchical numbering** (e.g., `01-01`, `13-02-01`, `99-01`):
 - **Key concepts**: Measuring state space reduction, scaling analysis
 - **Status**: ✅ BOTH PASSED
 - **How to use**: Run both files and compare state/node counts
+
+### 16-05-nominal-symmetry: Nominal Symmetry (symmetry module)
+- **State space**: 8 nodes, 4 unique states
+- **Purpose**: Interchangeable identifiers using `symmetry.nominal()`
+- **Key concepts**: `fresh()`, `values()`, `choices()`, `choose()`, unordered IDs
+- **Status**: ✅ PASSED
+
+### 16-06-ordinal-symmetry: Ordinal Symmetry (symmetry module)
+- **State space**: 5 nodes, 5 unique states
+- **Purpose**: Ordered values where only relative rank matters
+- **Key concepts**: `symmetry.ordinal()`, `fresh()`, `min()`, `max()`, ordering comparisons
+- **Status**: ✅ PASSED
+
+### 16-07-ordinal-segments: Ordinal Segments (gap insertion)
+- **State space**: 4 nodes, 1 unique state
+- **Purpose**: Inserting values between existing ordinal values using `segments()`
+- **Key concepts**: `segments()`, `segment.fresh()`, `after`/`before` filtering
+- **Status**: ✅ PASSED
+
+### 16-08-interval-symmetry: Interval Symmetry (symmetry module)
+- **State space**: 11 nodes, 11 unique states
+- **Purpose**: Ordered values where distance is meaningful, with arithmetic
+- **Key concepts**: `symmetry.interval()`, `val + int`, `val - int`, `val - val`, zero-shifting
+- **Status**: ✅ PASSED
+
+### 16-09-interval-divergence: Interval Divergence
+- **State space**: 5 nodes, 5 unique states
+- **Purpose**: Bounding the spread of interval values with `divergence` parameter
+- **Key concepts**: `divergence`, automatic spread enforcement, derivation rules
+- **Status**: ✅ PASSED
+
+### 16-10-rotational-symmetry: Rotational Symmetry (symmetry module)
+- **State space**: 11 nodes, 6 unique states
+- **Purpose**: Ring/modular arithmetic with wrapping values
+- **Key concepts**: `symmetry.rotational()`, `val + int` (wrapping), `val - val` (mod), ring positions
+- **Status**: ✅ PASSED
+
+### 16-11-reflection: Reflection Symmetry
+- **Files**: ReflectionInterval.fizz (6 states), ReflectionNoReflection.fizz (11 states), ReflectionRotational.fizz (7 states)
+- **Purpose**: Mirror-state equivalence using `reflection=True`
+- **Key concepts**: `reflection=True`, interval reflection (v-min vs max-v), rotational reflection (CW=CCW)
+- **Status**: ✅ ALL PASSED
+- **Note**: Compare ReflectionInterval.fizz (6 states) vs ReflectionNoReflection.fizz (11 states) for ~45% reduction
+
+### 16-12-materialize: Materialized Domains
+- **State space**: 23 nodes, 6 unique states
+- **Purpose**: Pre-populating all domain values with `materialize=True`
+- **Key concepts**: `materialize=True`, `values()` returns all upfront, `fresh()` disallowed
+- **Status**: ✅ PASSED
 
 ### 99-01-checkpoints: Visualization Checkpoints
 - **State space**: 12 nodes, 10 unique states


### PR DESCRIPTION
Add 10 new .fizz examples (16-05 through 16-12) covering all four symmetry types (nominal, ordinal, interval, rotational), reflection, divergence, ordinal segments, and materialize. Update LANGUAGE_REFERENCE.md with comprehensive symmetry module API section including quick reference tables, per-type documentation, and gotchas. Mark legacy symmetric_values() with recommendation to use the new API. All examples verified passing.