### PR TITLE
Add --playwright flag to MBT TypeScript generator

### DIFF
--- a/mbt/generator/main.py
+++ b/mbt/generator/main.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 import sys
 import os
 
@@ -48,6 +49,14 @@ def parse_args():
             default=None,
             help="Base directory to compute relative paths for spec references (default: same as --out-dir)"
         )
+        parser.add_argument(
+            "--playwright",
+            default=False,
+            action='store_true',
+            help="Generate a Playwright/browser adapter scaffold (TypeScript only): includes StateGetter, "
+                 "AfterActionHook, OverridesProvider, waitForDOMSettled, and role state stubs detected "
+                 "from Init action body. Implies --gen-adapter."
+        )
 
         args = parser.parse_args()
         if args.rel_root is None:
@@ -73,10 +82,49 @@ def parse_args():
             if not args.java_package:
                 parser.error("--java-package is required when --lang=java")
 
+        if args.playwright:
+            if args.lang != "typescript":
+                parser.error("--playwright is only supported with --lang=typescript")
+            # --playwright implies --gen-adapter
+            args.gen_adapter = True
+
         if not args.input_spec.endswith(".fizz"):
             print("Warning: input_spec does not end with .fizz", file=sys.stderr)
 
         return args
+
+def extract_role_state_fields(role):
+    """Extract state field names from a role's Init action by scanning PyStmt nodes.
+
+    Looks for top-level statements of the form ``self.fieldname = ...`` in the
+    Init action body.  These are the canonical state variable declarations in
+    FizzBee roles (all role state must be declared in ``action Init``).
+
+    Returns a list of field name strings in declaration order, deduplicated.
+    """
+    init_action = next((a for a in role.actions if a.name == "Init"), None)
+    if init_action is None:
+        return []
+    block = init_action.block
+    if not block:
+        return []
+
+    pattern = re.compile(r'^self\.(\w+)\s*=')
+    fields = []
+    seen = set()
+    for stmt in block.stmts:
+        # py_stmt.code is the raw Starlark text for simple assignment statements.
+        # It will be an empty string for non-PyStmt statements (blocks, ifs, etc.).
+        code = stmt.py_stmt.code.strip() if stmt.py_stmt.code else ""
+        if code:
+            m = pattern.match(code)
+            if m:
+                field = m.group(1)
+                if field not in seen:
+                    seen.add(field)
+                    fields.append(field)
+    return fields
+
 
 def main(argv):
     args = parse_args()
@@ -346,11 +394,21 @@ def generate_typescript(args, filename, parsedAst, data_path):
 
     env = Environment(loader=FileSystemLoader(os.path.join(data_path, "typescript")))
 
+    # Choose adapter template: playwright variant adds StateGetter, AfterActionHook,
+    # OverridesProvider, waitForDOMSettled, and per-role state field stubs.
+    adapter_template = "adapters.playwright.ts.j2" if args.playwright else "adapters.ts.j2"
+
     templates = [
         ("interfaces.ts.j2", "_interfaces", True, True),
-        ("adapters.ts.j2", "_adapters", args.gen_adapter, False),
+        (adapter_template, "_adapters", args.gen_adapter, False),
         ("test.ts.j2", "_test", True, True),
     ]
+
+    # Extract per-role state fields for the Playwright template (empty dict otherwise).
+    role_state_fields = {}
+    if args.playwright:
+        for role in parsedAst.roles:
+            role_state_fields[role.name] = extract_role_state_fields(role)
 
     for tpl_name, out_file_suffix, enabled, overwrite in templates:
         if not enabled:
@@ -362,6 +420,7 @@ def generate_typescript(args, filename, parsedAst, data_path):
             model_name=base_pascal_case(filename),
             model_base_name=model_base_name,
             source_path=rel_spec_path,
+            role_state_fields=role_state_fields,
         )
 
         out_file = typescript_filenames(filename, [out_file_suffix])[0]

--- a/mbt/generator/templates/typescript/adapters.playwright.ts.j2
+++ b/mbt/generator/templates/typescript/adapters.playwright.ts.j2
@@ -1,0 +1,132 @@
+// Generated Playwright scaffold by fizzbee-mbt generator
+// Source: {{ source_path }}
+// Implement the TODOs to connect your FizzBee spec to the real app under test.
+//
+// This scaffold includes:
+//   - StateGetter: maps real browser state to spec model state for assertion
+//   - AfterActionHook: waits for DOM to settle after every action
+//   - OverridesProvider: replaces spec constants with generated test data (fuzzing)
+//
+// Typical workflow:
+//   1. Implement init() / cleanup() / cleanupAll() with your PlaywrightEnv
+//   2. Implement each action method to drive the browser
+//   3. Implement getState() to read observable state (DOM, URL, localStorage)
+//   4. Optionally implement provideOverrides() for fuzz testing
+
+import { Arg, NotImplementedError, IGNORE, ignored, StateGetter,
+         AfterActionHook, OverridesProvider, OverridesBuilder, FuzzOptions, Tuple } from '@fizzbee/mbt';
+import { waitForDOMSettled } from '@fizzbee/mbt/playwright';
+import { Page } from 'playwright';
+import fc from 'fast-check';
+import { {% for role in file.roles %}{{ role.name }}Role, {% endfor %}{{ model_name }}Model } from './{{ model_base_name }}_interfaces.js';
+
+{% for role in file.roles %}
+// ── {{ role.name }} role adapter ───────────────────────────────────────────────
+export class {{ role.name }}RoleAdapter implements {{ role.name }}Role, StateGetter {
+  constructor(private readonly page: Page) {}
+
+  // Maps real browser state to the spec's model state for assertion.
+  // FizzBee compares the returned object against the spec state after every action.
+  //
+  // Sentinel values:
+  //   IGNORE        — field exists but value is not compared (e.g. DB-generated IDs)
+  //   ignored()     — unique placeholder map key whose value is not compared;
+  //                   use a fresh ignored() per entry so the map has the right size
+  async getState(): Promise<Record<string, any>> {
+    return {
+      {%- for field in role_state_fields[role.name] %}
+      // TODO: read {{ field }} from the browser (DOM, URL, localStorage, etc.)
+      {{ field }}: IGNORE,
+      {%- endfor %}
+    };
+  }
+
+  {%- for action in role.actions %}
+  {%- if action.name != "Init" %}
+  async action{{ action.name }}(args: Arg[]): Promise<any> {
+    // TODO: implement action {{ action.name }}
+    // args[] contains the nondeterministic choices from the spec in declaration order.
+    throw new NotImplementedError('{{ role.name }}.action{{ action.name }} not implemented');
+  }
+  {%- endif %}
+  {%- endfor %}
+}
+{% endfor %}
+// ── Model adapter ──────────────────────────────────────────────────────────────
+// Manages browser lifecycle and wires roles to the test runner.
+export class {{ model_name }}ModelAdapter implements {{ model_name }}Model, AfterActionHook, OverridesProvider {
+  private page?: Page;
+  {% for role in file.roles -%}
+  private {{ role.name | lower }}Role?: {{ role.name }}RoleAdapter;
+  {% endfor %}
+  // init() is called before each test run — create a fresh page and reset app state.
+  async init(): Promise<void> {
+    // TODO: create a page via your PlaywrightEnv and navigate to the app.
+    // Example using PlaywrightEnv (see playwright_env.ts for a reference impl):
+    //   this.page = await this.env.createPage();
+    //   this.{{ file.roles[0].name | lower }}Role = new {{ file.roles[0].name }}RoleAdapter(this.page!);
+    throw new NotImplementedError('init not implemented');
+  }
+
+  // cleanup() is called after each test run — close/reset the page.
+  async cleanup(): Promise<void> {
+    // TODO: close the page (called between every test trace).
+    // Example: await this.env.closePage(this.page!);
+  }
+
+  // cleanupAll() is called once at the very end — close the browser.
+  async cleanupAll(): Promise<void> {
+    // TODO: close the browser and any shared resources.
+    // Example: await this.env.closeAll();
+  }
+
+  // Called after every action — waits for all DOM mutations to settle.
+  // Do not replace this with waitForTimeout; waitForDOMSettled is precise and fast.
+  async afterAction(): Promise<void> {
+    await waitForDOMSettled(this.page as any, { debounceTimeout: 1 });
+  }
+
+  // Called once per fuzz run — override spec constants with generated test data.
+  // The seed in options makes runs reproducible.
+  provideOverrides(builder: OverridesBuilder, options: FuzzOptions): void {
+    // TODO: override spec constants with fast-check generated values.
+    // Example for a TODO_STRINGS constant:
+    //   const samples = fc.sample(
+    //     fc.string({ unit: 'grapheme', minLength: 1, maxLength: 30 })
+    //       .filter(s => s.trim().length > 0),
+    //     { seed: options.seed, numRuns: 3 }
+    //   );
+    //   builder.setTuple('TODO_STRINGS', new Tuple(...samples));
+  }
+
+  async getRoles(): Promise<Map<string, any>> {
+    const roles = new Map<string, any>();
+    {% for role in file.roles -%}
+    roles.set('{{ role.name }}#0', this.{{ role.name | lower }}Role);
+    {% endfor -%}
+    return roles;
+  }
+
+  {%- for action in file.actions %}
+  {%- if action.name != "Init" %}
+
+  async action{{ action.name }}(args: Arg[]): Promise<any> {
+    // TODO: implement action {{ action.name }}
+    throw new NotImplementedError('action{{ action.name }} not implemented');
+  }
+  {%- endif %}
+  {%- endfor %}
+}
+
+export function new{{ model_name }}Model(): {{ model_name }}Model {
+  return new {{ model_name }}ModelAdapter();
+}
+
+export function getTestOptions(): Record<string, any> {
+  return {
+    'max-seq-runs': 1000,
+    'max-parallel-runs': 0,      // Playwright is not thread-safe; sequential only
+    'max-fuzz-seq-runs': 4,
+    'max-actions': 10,
+  };
+}


### PR DESCRIPTION
Adds a --playwright flag (TypeScript only, implies --gen-adapter) that selects a Playwright-specific adapter scaffold instead of the generic one.

Changes:
- mbt/generator/main.py: new --playwright arg, validation, template selection, and extract_role_state_fields() which scans each role's Init action body for `self.field = ...` assignments to auto-detect state fields
- mbt/generator/templates/typescript/adapters.playwright.ts.j2: new Jinja2 template that generates StateGetter.getState() stubs (one per detected state field), AfterActionHook.afterAction() with waitForDOMSettled, and OverridesProvider.provideOverrides() with a fast-check example; sets max-parallel-runs=0 since Playwright is not thread-safe