### PR TITLE
Support --trace-extend without a trace to explore N steps from Init

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	//fmt.Println("dirPath:", dirPath)
 	// Calculate the relative path
 	var stateConfig *ast.StateSpaceOptions
-	if traceFile != "" || trace != "" {
+	if traceFile != "" || trace != "" || traceExtend > 0 {
 		stateConfig = getStateConfigForTraceChecking(stateConfig)
 	} else {
 		stateConfig = loadStateOptions(dirPath, f.GetFrontMatter())
@@ -542,6 +542,15 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 			fmt.Println("Error: --trace and --simulation cannot be used together")
 			return nil
 		}
+	} else if traceExtend > 0 {
+		// No trace specified but --trace-extend given: explore traceExtend steps
+		// from the initial state (empty trace). guidedTrace with no LinkNames but
+		// ExtendDepth > 0 signals "explore N steps from Init" to ShouldScheduleNode.
+		if simulation {
+			fmt.Println("Error: --trace-extend and --simulation cannot be used together")
+			return nil
+		}
+		guidedTrace = &modelchecker.GuidedTrace{}
 	}
 
 	// Set trace extension depth if configured

--- a/modelchecker/trace.go
+++ b/modelchecker/trace.go
@@ -97,7 +97,7 @@ func (t *GuidedTrace) GetCurrentIndex() int {
 // Returns true if the node should be added to the queue
 // This is called before adding nodes to the queue to filter based on trace
 func (p *Processor) ShouldScheduleNode(node *Node) bool {
-	if len(node.guidedTrace.LinkNames) == 0 {
+	if len(node.guidedTrace.LinkNames) == 0 && node.guidedTrace.ExtendDepth == 0 {
 		return true // Not in trace mode, schedule everything
 	}
 


### PR DESCRIPTION
When --trace-extend N is given without --trace or --trace-file, create an empty GuidedTrace so the checker explores exactly N steps from the initial state instead of doing a full BFS.

Two supporting fixes:
- Apply trace-checking config (deadlock detection off, liveness off) when traceExtend > 0, matching the behaviour of --trace and --trace-file.
- ShouldScheduleNode: treat empty LinkNames + ExtendDepth > 0 as "limited trace mode" rather than "no trace = schedule everything", so the extend depth is respected.

Use case: interactive state explorer that calls the model checker on demand to get the initial state + enabled actions without pre-generating the full state space.