### PR TITLE
trace: yield-aware boundary + skip exists-witness in trace mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -636,16 +636,23 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 			}
 			if !simulation {
 				fmt.Println("Valid Nodes:", len(nodes), "Unique states:", yieldsCount)
-				invariants := modelchecker.CheckSimpleExistsWitness(nodes)
-				if len(invariants) > 0 {
-					fmt.Println("\nFAILED: Expected states never reached")
-					for i2, invariant := range invariants {
-						fmt.Printf("Invariant %d: %s\n", i2, f.Invariants[invariant.InvariantIndex].Name)
+				// Skip the exists-witness check in trace mode: a guided trace
+				// only explores a slice of the state space, so `exists`
+				// invariants legitimately can't be satisfied yet. Letting the
+				// failure short-circuit here would also skip writing the
+				// nodes/links pb files, which the trace consumer needs.
+				if guidedTrace == nil {
+					invariants := modelchecker.CheckSimpleExistsWitness(nodes)
+					if len(invariants) > 0 {
+						fmt.Println("\nFAILED: Expected states never reached")
+						for i2, invariant := range invariants {
+							fmt.Printf("Invariant %d: %s\n", i2, f.Invariants[invariant.InvariantIndex].Name)
+						}
+						if !isTest {
+							fmt.Println("Time taken to check invariant: ", time.Now().Sub(endTime))
+						}
+						return nil
 					}
-					if !isTest {
-						fmt.Println("Time taken to check invariant: ", time.Now().Sub(endTime))
-					}
-					return nil
 				}
 			}
 			if !simulation && !p1.Stopped() && guidedTrace == nil {

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -1626,6 +1626,13 @@ func (p *Processor) processNode(node *Node) (bool, bool) {
 	}
 
 	if yield {
+		// Mark this node as a yield BEFORE scheduling its successors. The
+		// trace-extend yield-aware boundary check in ShouldScheduleNode reads
+		// parent.Process.IsYieldNode(), which depends on Name being set; if we
+		// scheduled first and labelled later, every successor would see a
+		// non-yield parent and the extension would never bound.
+		node.Name = "yield"
+
 		if len(forks) > 0 {
 			//fmt.Println("yield and fork at the same time")
 			for _, fork := range forks {
@@ -1634,7 +1641,6 @@ func (p *Processor) processNode(node *Node) (bool, bool) {
 		} else {
 			p.YieldNode(node)
 		}
-		node.Name = "yield"
 
 		if p.shouldThreadCrash(node) {
 			p.crashThread(node)

--- a/modelchecker/trace.go
+++ b/modelchecker/trace.go
@@ -116,12 +116,27 @@ func (p *Processor) ShouldScheduleNode(node *Node) bool {
 
 	// Check if trace is exhausted
 	if node.guidedTrace.IsExhausted() {
-		// Allow extension if configured
-		if node.guidedTrace.ExtendDepth > 0 && node.guidedTrace.extendedCount < node.guidedTrace.ExtendDepth {
-			node.guidedTrace.extendedCount++
-			return true
+		if node.guidedTrace.ExtendDepth == 0 {
+			return false
 		}
-		return false
+		// Count every scheduled node past the trace end as before. The twist:
+		// after the count reaches ExtendDepth we still need to push through any
+		// non-yield branch nodes (e.g. `oneof` choices) to reach the next yield
+		// boundary, otherwise the state graph stores partial/intermediate states
+		// the explorer can't walk back to.
+		//
+		// So: when the budget is exhausted, only refuse to schedule when the
+		// parent is a yield node — that's the natural stopping point. If the
+		// parent is non-yield, keep scheduling until we hit a yield.
+		if node.guidedTrace.extendedCount >= node.guidedTrace.ExtendDepth {
+			parent := node.Inbound[0].Node
+			parentIsYield := parent != nil && parent.Process != nil && parent.Process.IsYieldNode()
+			if parentIsYield {
+				return false
+			}
+		}
+		node.guidedTrace.extendedCount++
+		return true
 	}
 
 	// Get the next expected link name from trace


### PR DESCRIPTION
Builds on #335. Three refinements:

1. ShouldScheduleNode bounds the extension at yield boundaries. After ExtendDepth nodes are scheduled, refuse to schedule only when the parent is a yield node. Non-yield branches (e.g. oneof choices) keep getting scheduled until the next yield, so the graph stops at coherent states the explorer can traverse, not mid-action partial states.

2. processor.go: set node.Name = "yield" BEFORE scheduling successors, so ShouldScheduleNode's parent.Process.IsYieldNode() check sees the correct label. Without this, the yield-aware bound never fires.

3. main.go: skip CheckSimpleExistsWitness in trace mode. A guided trace only explores a slice of the state space; exists invariants can't be satisfied in that slice, and short-circuiting the failure prevents the nodes/links pb files from being written, which the trace consumer (e.g. fizzbee-studio's explorer) needs.