### PR TITLE
fix: handle DisableTransitionError in arg/default/if evaluation paths

### DIFF
--- a/modelchecker/thread.go
+++ b/modelchecker/thread.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/fizzbee-io/fizzbee/lib"
+	"github.com/golang/glog"
 
 	"hash"
 	"maps"
@@ -618,7 +619,20 @@ func (t *Thread) executeStatement() ([]*Process, bool) {
 			symCtx := t.Process.createSymmetryContext()
 			cond, err := t.Process.Evaluator.EvalExprWithContext(t.getFileName(), conditionExpr, vars, symCtx)
 			t.Process.saveRotationalLastAllocated(symCtx)
-			t.Process.PanicOnError(conditionExpr.GetSourceInfo(), fmt.Sprintf("Error checking condition: %s", branch.Condition), err)
+			if err != nil {
+				if lib.IsDisableTransitionError(err) {
+					// e.g. `if domain.fresh() != None:` exhausting its limit —
+					// disable the whole transition. Note: control does NOT
+					// fall through to elif/else; the action is simply not
+					// taken from this state.
+					glog.V(2).Infof("transition disabled at if-condition: %s (cond=%q)", err, branch.Condition)
+					t.Process.Enabled = false
+					t.Process.ThreadProgress = false
+					t.Aborted = true
+					return nil, false
+				}
+				t.Process.PanicOnError(conditionExpr.GetSourceInfo(), fmt.Sprintf("Error checking condition: %s", branch.Condition), err)
+			}
 			t.Process.updateAllVariablesInScope(vars)
 			if cond.Truth() {
 				currentFrame.pc = fmt.Sprintf("%s.IfStmt.Branches[%d].Block", currentFrame.pc, i)
@@ -920,9 +934,20 @@ func (t *Thread) executeStatement() ([]*Process, bool) {
 				symCtx := t.Process.createSymmetryContext()
 				val, err := t.Process.Evaluator.EvalExprWithContext(t.getFileName(), arg.Expr, vars, symCtx)
 				t.Process.saveRotationalLastAllocated(symCtx)
-				// TODO: This source info should be for the pyExpr not the callStmt
-				t.Process.PanicOnError(arg.Expr.GetSourceInfo(), fmt.Sprintf("Error evaluating expr: %s", arg.PyExpr), err)
-				//PanicOnError(err)
+				if err != nil {
+					if lib.IsDisableTransitionError(err) {
+						// e.g. `domain.fresh()` exhausting its limit when used
+						// directly as a call argument — disable the transition
+						// instead of panicking.
+						glog.V(2).Infof("transition disabled at call-arg expr: %s (expr=%q)", err, arg.PyExpr)
+						t.Process.Enabled = false
+						t.Process.ThreadProgress = false
+						t.Aborted = true
+						return nil, false
+					}
+					// TODO: This source info should be for the pyExpr not the callStmt
+					t.Process.PanicOnError(arg.Expr.GetSourceInfo(), fmt.Sprintf("Error evaluating expr: %s", arg.PyExpr), err)
+				}
 				t.Process.updateAllVariablesInScope(vars)
 				if !hasNamedArgs && arg.Name == "" {
 					if i >= len(def.params) {
@@ -944,8 +969,18 @@ func (t *Thread) executeStatement() ([]*Process, bool) {
 						symCtx := t.Process.createSymmetryContext()
 						val, err := t.Process.Evaluator.EvalExprWithContext(t.getFileName(), param.DefaultExpr, vars, symCtx)
 						t.Process.saveRotationalLastAllocated(symCtx)
-						t.Process.PanicOnError(param.GetDefaultExpr().GetSourceInfo(), fmt.Sprintf("Error evaluating expr: %s", param.DefaultPyExpr), err)
-						//PanicOnError(err)
+						if err != nil {
+							if lib.IsDisableTransitionError(err) {
+								// Default parameter expression couldn't be evaluated
+								// (e.g. domain.fresh() exhausted) — disable the transition.
+								glog.V(2).Infof("transition disabled at default-param expr: %s (expr=%q)", err, param.DefaultPyExpr)
+								t.Process.Enabled = false
+								t.Process.ThreadProgress = false
+								t.Aborted = true
+								return nil, false
+							}
+							t.Process.PanicOnError(param.GetDefaultExpr().GetSourceInfo(), fmt.Sprintf("Error evaluating expr: %s", param.DefaultPyExpr), err)
+						}
 						t.Process.updateAllVariablesInScope(vars)
 						newFrame.vars[param.Name] = val
 					} else {


### PR DESCRIPTION
Three sites in modelchecker/thread.go evaluate Starlark expressions and called PanicOnError directly on the error, ignoring the DisableTransitionError contract. domain.fresh() exhausting its limit returns a DisableTransitionError that should disable the current transition (matching the existing PyStmt path at lines ~595, ~893), but in argument-evaluation, default-parameter, and if-condition evaluation paths it became a fatal panic.

Apply the same disable-transition handling at all three sites and add glog.V(2) debug logs so disabled transitions are observable when enabled with -v=2 or -vmodule=thread=2.

Note for if-condition: when an if-condition expression returns DisableTransitionError, the whole transition is disabled — control does NOT fall through to elif/else. This matches the principle "DisableTransitionError is never fatal" but is a semantic constraint worth knowing about (documented in the inline comment).

Repro: any spec that calls domain.fresh() directly as a call argument with a small enough domain limit and stale role views holding tokens across iterations. Was hit in fizzbee-studio expense-splitter analysis where simulation panicked but full check ran fine — simulation reaches exhaustion sooner than BFS does, but both paths now disable cleanly.