### PR TITLE
feat: add sum() builtin function

### DIFF
--- a/examples/references/LANGUAGE_REFERENCE.md
+++ b/examples/references/LANGUAGE_REFERENCE.md
@@ -2138,12 +2138,16 @@ Always in scope, no qualifier needed:
 | `genericset()` | Set that supports non-hashable values (records, lists, dicts). Implemented via linear scan rather than hashing — minor performance cost, irrelevant at model-checker scale where collections hold a handful of entries. Use this when you need a set of records. |
 | `genericmap()` | Map that supports non-hashable keys (records, lists, dicts). Same linear-scan implementation rationale as `genericset`. |
 | `bag()` | Mutable multiset (counts duplicates). Methods: `add`, `add_all`, `clear`, `discard`, `pop`, `remove`. |
+| `sum(iterable, start=0)` | Sum a list/set/bag/tuple of numbers. Returns `int` if all values are ints, `float` otherwise. Example: `sum([a.balance for a in accounts])`. |
 | `symmetric_values(name, n)` | **Legacy.** Use the `symmetry` module instead (see below). |
 
-Plus everything Starlark provides: `len`, `range`, `min`, `max`, `sum`,
-`sorted`, `reversed`, `zip`, `enumerate`, `any`, `all` (the predicate, not
-the deprecated nondeterminism alias), `print`, `type`, `int`, `str`,
+Plus everything Starlark provides: `len`, `range`, `min`, `max`,
+`sorted`, `reversed`, `zip`, `enumerate`, `all`, `print`, `type`, `int`, `str`,
 `bool`, `float`, `list`, `dict`, `set`, `tuple`.
+
+**Note on `any`**: `any` is a reserved keyword in FizzBee (deprecated alias
+for `oneof`). The Python `any([...])` predicate form is a **parse error**.
+Use `len([x for x in xs if cond]) > 0` instead.
 
 ### `math` module
 

--- a/lib/starlark_types.go
+++ b/lib/starlark_types.go
@@ -40,6 +40,7 @@ var (
 		"math":             math.Module,
 		"itertools":        ItertoolsModule,
 		"symmetry":         SymmetryModule,
+		"sum":              starlark.NewBuiltin("sum", builtinSum),
 	}
 
 	StarlarkPtrTypes = []starlark.Value{
@@ -90,6 +91,41 @@ var (
 		"remove":  starlark.NewBuiltin("remove", bag_remove),
 	}
 )
+
+// builtinSum implements sum(iterable, start=0), matching Python's semantics.
+// Returns an int if all values are ints, otherwise a float.
+// Uses starlark.Binary for addition so int/float coercion is handled automatically.
+func builtinSum(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var iterable starlark.Iterable
+	start := starlark.Value(starlark.MakeInt(0))
+	if err := starlark.UnpackPositionalArgs("sum", args, kwargs, 1, &iterable, &start); err != nil {
+		return nil, err
+	}
+	switch start.(type) {
+	case starlark.Int, starlark.Float:
+	default:
+		return nil, fmt.Errorf("sum: start must be a number, got %s", start.Type())
+	}
+
+	acc := start
+	iter := iterable.Iterate()
+	defer iter.Done()
+
+	var x starlark.Value
+	for iter.Next(&x) {
+		switch x.(type) {
+		case starlark.Int, starlark.Float:
+		default:
+			return nil, fmt.Errorf("sum: unsupported type %s", x.Type())
+		}
+		var err error
+		acc, err = starlark.Binary(syntax.PLUS, acc, x)
+		if err != nil {
+			return nil, fmt.Errorf("sum: %v", err)
+		}
+	}
+	return acc, nil
+}
 
 type SymmetricValues struct {
 	starlark.Tuple


### PR DESCRIPTION
Implements Python-compatible sum(iterable, start=0). Uses starlark.Binary(PLUS) internally so int+int→int and int+float→float coercions are handled automatically, with full big-integer support.

Useful for conservation invariants and quorum checks in specs:
  sum([a.balance for a in accounts]) == TOTAL
  sum([1 for n in nodes if n.voted]) >= QUORUM

Also updates LANGUAGE_REFERENCE.md: adds sum() to the builtins table, removes it from the incorrect "Starlark provides" list, and fixes the any() predicate claim (it's a parse error in assignment context).