### PR TITLE
fix: write dot files once at end of simulation, not per-run

### DIFF
--- a/fizz
+++ b/fizz
@@ -168,7 +168,7 @@ usage() {
   echo "Usage:"
   echo "  $0 install-skills [--check | --remove]"
   echo "  $0 mbt-scaffold [options] filename"
-  echo "  $0 [-x|--simulation] [--test] [--seed int64Number] [--max_runs intNumber] [--exploration_strategy dfs] [--trace-file tracefile | --trace tracestring] [--preinit-hook-file hookfile | --preinit-hook hookstring] [--copy-ast] [--no-copy-ast] [--output-dir directory] filename"
+  echo "  $0 [-x|--simulation] [--test] [--seed int64Number] [--max_runs intNumber] [--simulation_first_traces intNumber] [--exploration_strategy dfs] [--trace-file tracefile | --trace tracestring] [--preinit-hook-file hookfile | --preinit-hook hookstring] [--copy-ast] [--no-copy-ast] [--output-dir directory] filename"
   exit 1
 }
 
@@ -176,6 +176,7 @@ usage() {
 simulation=false
 seed=0
 max_runs=0
+simulation_first_traces=0
 exploration_strategy=bfs
 test=false
 copy_ast=true
@@ -212,6 +213,15 @@ while [[ "$1" =~ ^- ]]; do
         shift 2
       else
         echo "Error: --max_runs requires a numeric value." 1>&2
+        usage
+      fi
+      ;;
+    --simulation_first_traces )
+      if [[ -n "$2" ]] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        simulation_first_traces="$2"
+        shift 2
+      else
+        echo "Error: --simulation_first_traces requires a numeric value." 1>&2
         usage
       fi
       ;;
@@ -347,6 +357,9 @@ if [ "$seed" -ne 0 ]; then
 fi
 if [ "$max_runs" -ne 0 ]; then
   args+=("--max_runs" "$max_runs")
+fi
+if [ "$simulation_first_traces" -ne 0 ]; then
+  args+=("--simulation_first_traces" "$simulation_first_traces")
 fi
 if [ "$exploration_strategy" != "bfs" ]; then
   args+=("--exploration_strategy" "$exploration_strategy")

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var copyAst bool
 var outputDir string
 var seed int64
 var maxRuns int
+var simFirstTraces int
 var explorationStrategy string
 var traceFile string
 var preinitHookFile string
@@ -586,6 +587,7 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 	runs := 0
 	var p1 *modelchecker.Processor
 	var holder atomic.Pointer[modelchecker.Processor]
+	var lastRootNode *modelchecker.Node
 
 	setupSignalHandler(&holder, &stopped)
 
@@ -598,9 +600,14 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 
 		rootNode, failedNode, endTime, err := startModelChecker(p1)
 		runs++
+		lastRootNode = rootNode
 
-		if writeDotFileIfNeeded(p1, rootNode, outDir) {
-			return nil
+		if !simulation {
+			if writeDotFileIfNeeded(p1, rootNode, outDir) {
+				return nil
+			}
+		} else if i <= simFirstTraces {
+			writeDotFileIfNeeded(p1, rootNode, outDir)
 		}
 
 		if err != nil {
@@ -712,6 +719,14 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 		}
 	}
 	fmt.Println("Stopped after", runs, "runs at ", time.Now())
+	if simulation && p1 != nil {
+		if runs-simFirstTraces > 1 {
+			fmt.Println("Not printing intermediate traces (only the last trace is shown)")
+		}
+		if runs > simFirstTraces {
+			writeDotFileIfNeeded(p1, lastRootNode, outDir)
+		}
+	}
 	return nil
 }
 
@@ -867,6 +882,7 @@ func parseFlags() []string {
 	flag.StringVar(&outputDir, "output-dir", "", "Custom output directory path (if not specified, uses default SPEC_DIR/out/run_timestamp)")
 	flag.Int64Var(&seed, "seed", 0, "Seed for random number generator used in simulation mode")
 	flag.IntVar(&maxRuns, "max_runs", 0, "Maximum number of simulation runs/paths to explore. Default=0 for unlimited")
+	flag.IntVar(&simFirstTraces, "simulation_first_traces", 0, "In simulation mode, write dot files for the first N runs (default 0). The last run is always written.")
 	flag.StringVar(&explorationStrategy, "exploration_strategy", "bfs", "Exploration strategy for exhaustive model checking. Options: bfs (default), dfs, random.")
 	flag.StringVar(&traceFile, "trace-file", "", "Path to trace file for guided execution")
 	flag.StringVar(&preinitHookFile, "preinit-hook-file", "", "Path to Starlark file to execute after preinit but before freezing globals")


### PR DESCRIPTION
In simulation mode with --max_runs N, the dot file was written after every iteration. Now:
- The last run's dot file is always written after the loop completes
- Intermediate runs are skipped with a log message
- New flag --simulation_first_traces N (default 0) writes dot files for the first N runs in addition to the last, useful for debugging