### PR TITLE
refactor(lovable): rename Server→System, db→system, any→oneof

### DIFF
--- a/examples/requirements/lovable/01-todo-app/TodoApp.fizz
+++ b/examples/requirements/lovable/01-todo-app/TodoApp.fizz
@@ -28,7 +28,7 @@ Filter = enum("All", "Pending", "Completed")
 # Ground truth. Supabase Postgres with RLS.
 # Stored as a list to preserve insertion order (ORDER BY created_at ASC).
 
-role Server:
+role System:
     action Init:
         self.todos = []
 
@@ -63,53 +63,51 @@ role User:
 
     atomic func RefreshView():
         if self.filter == Filter.All:
-            self.view = db.todos
+            self.view = system.todos
         elif self.filter == Filter.Pending:
-            self.view = [t for t in db.todos if not t.done]
+            self.view = [t for t in system.todos if not t.done]
         else:
-            self.view = [t for t in db.todos if t.done]
-        self.completed_exist = len([t for t in db.todos if t.done]) > 0
+            self.view = [t for t in system.todos if t.done]
+        self.completed_exist = len([t for t in system.todos if t.done]) > 0
 
     # ── CRUD ──
 
     atomic action AddTodo:
         id = IDS.fresh()
-        text = any TEXTS.choices()
-        db.AddTodo(id, text)
+        text = oneof TEXTS.choices()
+        system.AddTodo(id, text)
         self.RefreshView()
 
     atomic action ToggleTodo:
-        require len(self.view) > 0
-        index = any range(len(self.view))
+        index = oneof range(len(self.view))
         item = self.view[index]
-        db.ToggleTodo(item.id)
+        system.ToggleTodo(item.id)
         self.RefreshView()
 
     atomic action DeleteTodo:
-        require len(self.view) > 0
-        index = any range(len(self.view))
+        index = oneof range(len(self.view))
         item = self.view[index]
-        db.DeleteTodo(item.id)
+        system.DeleteTodo(item.id)
         self.RefreshView()
 
     # ── Filter & bulk ──
 
     atomic fair action SwitchFilter:
-        require len(db.todos) > 0
-        new_filter = fair any [f for f in dir(Filter) if self.filter != f]
+        require len(system.todos) > 0
+        new_filter = fair oneof [f for f in dir(Filter) if self.filter != f]
         self.filter = new_filter
         self.RefreshView()
 
     atomic action ClearCompleted:
         require self.completed_exist
-        db.ClearCompleted()
+        system.ClearCompleted()
         self.RefreshView()
 
 
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     user = User()
 
 
@@ -119,19 +117,19 @@ action Init:
 #     Catches filter-logic bugs across all possible action sequences.
 always assertion ViewMatchesFilter:
     if user.filter == Filter.All:
-        expected = db.todos
+        expected = system.todos
     elif user.filter == Filter.Pending:
-        expected = [t for t in db.todos if not t.done]
+        expected = [t for t in system.todos if not t.done]
     else:
-        expected = [t for t in db.todos if t.done]
+        expected = [t for t in system.todos if t.done]
     return user.view == expected
 
 # R2: The "Clear Completed" button visibility stays in sync with the DB.
 always assertion CompletedFlagConsistent:
-    has_completed = len([t for t in db.todos if t.done]) > 0
+    has_completed = len([t for t in system.todos if t.done]) > 0
     return user.completed_exist == has_completed
 
 # R3: No duplicate todo IDs.
 always assertion UniqueTodoIds:
-    ids = [t.id for t in db.todos]
+    ids = [t.id for t in system.todos]
     return len(ids) == len(set(ids))

--- a/examples/requirements/lovable/02-poll/Poll.fizz
+++ b/examples/requirements/lovable/02-poll/Poll.fizz
@@ -25,7 +25,7 @@ Status = enum("Open", "Closed")
 # polls table: status, options (fixed set)
 # votes table: voter_id -> option (one vote per voter, can update)
 
-role Server:
+role System:
     action Init:
         self.status = Status.Open
         self.votes = {}
@@ -53,34 +53,34 @@ role Voter:
         self.poll_open = True
 
     atomic func RefreshView():
-        self.poll_open = (db.status == Status.Open)
-        if self.__id__ in db.votes:
-            self.my_vote = db.votes[self.__id__]
+        self.poll_open = (system.status == Status.Open)
+        if self.__id__ in system.votes:
+            self.my_vote = system.votes[self.__id__]
         else:
             self.my_vote = None
 
     atomic action Vote:
         require self.poll_open
         require self.my_vote == None
-        option = any OPTIONS.choices()
-        db.CastVote(self.__id__, option)
+        option = oneof OPTIONS.choices()
+        system.CastVote(self.__id__, option)
         self.RefreshView()
 
     atomic action ChangeVote:
         require self.poll_open
         require self.my_vote != None
-        new_option = any [o for o in OPTIONS.choices() if o != self.my_vote]
-        db.CastVote(self.__id__, new_option)
+        new_option = oneof [o for o in OPTIONS.choices() if o != self.my_vote]
+        system.CastVote(self.__id__, new_option)
         self.RefreshView()
 
     atomic action RetractVote:
         require self.poll_open
         require self.my_vote != None
-        db.RemoveVote(self.__id__)
+        system.RemoveVote(self.__id__)
         self.RefreshView()
 
     atomic fair action RefreshPollStatus:
-        require self.poll_open and db.status == Status.Closed
+        require self.poll_open and system.status == Status.Closed
         self.RefreshView()
 
 
@@ -93,14 +93,14 @@ role Creator:
 
     atomic action ClosePoll:
         require not self.closed
-        db.ClosePoll()
+        system.ClosePoll()
         self.closed = True
 
 
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     creator = Creator()
     voters = bag()
     for i in range(NUM_VOTERS):
@@ -112,8 +112,8 @@ action Init:
 # R1: After refresh, each voter's local my_vote matches the database.
 always assertion VoterViewConsistent:
     for v in voters:
-        if v.__id__ in db.votes:
-            if v.my_vote != None and v.my_vote != db.votes[v.__id__]:
+        if v.__id__ in system.votes:
+            if v.my_vote != None and v.my_vote != system.votes[v.__id__]:
                 return False
         else:
             if v.my_vote != None and not v.poll_open:
@@ -122,12 +122,12 @@ always assertion VoterViewConsistent:
 
 # R2: Once the poll is closed, the votes never change.
 transition assertion ClosedPollIsImmutable(before, after):
-    if before.db.status == Status.Closed:
-        return before.db.votes == after.db.votes
+    if before.system.status == Status.Closed:
+        return before.system.votes == after.system.votes
     return True
 
 # R3: Once the poll is closed, it stays closed.
 transition assertion ClosedStaysClosed(before, after):
-    if before.db.status == Status.Closed:
-        return after.db.status == Status.Closed
+    if before.system.status == Status.Closed:
+        return after.system.status == Status.Closed
     return True

--- a/examples/requirements/lovable/03-booking/Booking.fizz
+++ b/examples/requirements/lovable/03-booking/Booking.fizz
@@ -22,7 +22,7 @@ SLOTS = symmetry.nominal(name="slot", limit=NUM_SLOTS)
 # ─── Server (Database) ───────────────────────────────────────────────
 # slots table: slot_id -> guest_id or None (None = available)
 
-role Server:
+role System:
     action Init:
         self.slots = {}
 
@@ -46,25 +46,24 @@ symmetric role Guest:
         self.my_booking = None
 
     atomic func RefreshView():
-        self.view_available = [s for s in db.slots if db.slots[s] == None]
+        self.view_available = [s for s in system.slots if system.slots[s] == None]
         # Check if I still have a booking
         self.my_booking = None
-        for s in db.slots:
-            if db.slots[s] == self.__id__:
+        for s in system.slots:
+            if system.slots[s] == self.__id__:
                 self.my_booking = s
 
     # Guest sees available slots and picks one to book
     atomic action BookSlot:
         require self.my_booking == None
-        require len(self.view_available) > 0
-        slot = any self.view_available
-        db.BookSlot(slot, self.__id__)
+        slot = oneof self.view_available
+        system.BookSlot(slot, self.__id__)
         self.RefreshView()
 
     # Guest cancels their existing booking
     atomic action CancelBooking:
         require self.my_booking != None
-        db.CancelBooking(self.my_booking, self.__id__)
+        system.CancelBooking(self.my_booking, self.__id__)
         self.RefreshView()
 
     # Guest refreshes their browser to see latest availability
@@ -76,10 +75,10 @@ symmetric role Guest:
 # Host creates slots, then guests join. Slot creation is setup, not ongoing behavior.
 
 action Init:
-    db = Server()
+    system = System()
     for i in range(NUM_SLOTS):
         slot_id = SLOTS.fresh()
-        db.slots[slot_id] = None
+        system.slots[slot_id] = None
     guests = bag()
     for i in range(NUM_GUESTS):
         guests.add(Guest())
@@ -89,13 +88,13 @@ action Init:
 
 # R1: Each slot has at most one guest assigned.
 always assertion NoDoubleBooking:
-    booked_guests = [db.slots[s] for s in db.slots if db.slots[s] != None]
+    booked_guests = [system.slots[s] for s in system.slots if system.slots[s] != None]
     return len(booked_guests) == len(set(booked_guests))
 
 # R2: A guest holds at most one booking at a time.
 always assertion OneBookingPerGuest:
     for g in guests:
-        count = len([s for s in db.slots if db.slots[s] == g.__id__])
+        count = len([s for s in system.slots if system.slots[s] == g.__id__])
         if count > 1:
             return False
     return True

--- a/examples/requirements/lovable/04-kanban/Kanban.fizz
+++ b/examples/requirements/lovable/04-kanban/Kanban.fizz
@@ -28,7 +28,7 @@ Column = enum("Todo", "InProgress", "Done")
 # cards table: list of records preserving creation order
 # Each card has: id, title, column
 
-role Server:
+role System:
     action Init:
         self.cards = []
 
@@ -62,42 +62,39 @@ symmetric role User:
         self.view = []
 
     atomic func RefreshView():
-        self.view = db.cards
+        self.view = system.cards
 
     # Add a new card to the Todo column
     atomic action AddCard:
         id = IDS.fresh()
-        title = any TITLES.choices()
-        db.AddCard(id, title)
+        title = oneof TITLES.choices()
+        system.AddCard(id, title)
         self.RefreshView()
 
     # Move a card to the next column (Todo->InProgress->Done)
     atomic action MoveCardForward:
         movable = [c for c in self.view if c.col != Column.Done]
-        require len(movable) > 0
-        card = any movable
+        card = oneof movable
         if card.col == Column.Todo:
-            db.MoveCard(card.id, Column.Todo, Column.InProgress)
+            system.MoveCard(card.id, Column.Todo, Column.InProgress)
         elif card.col == Column.InProgress:
-            db.MoveCard(card.id, Column.InProgress, Column.Done)
+            system.MoveCard(card.id, Column.InProgress, Column.Done)
         self.RefreshView()
 
     # Move a card back (Done->InProgress->Todo)
     atomic action MoveCardBack:
         movable = [c for c in self.view if c.col != Column.Todo]
-        require len(movable) > 0
-        card = any movable
+        card = oneof movable
         if card.col == Column.Done:
-            db.MoveCard(card.id, Column.Done, Column.InProgress)
+            system.MoveCard(card.id, Column.Done, Column.InProgress)
         elif card.col == Column.InProgress:
-            db.MoveCard(card.id, Column.InProgress, Column.Todo)
+            system.MoveCard(card.id, Column.InProgress, Column.Todo)
         self.RefreshView()
 
     # Delete a card
     atomic action DeleteCard:
-        require len(self.view) > 0
-        card = any self.view
-        db.DeleteCard(card.id)
+        card = oneof self.view
+        system.DeleteCard(card.id)
         self.RefreshView()
 
     # Refresh to see latest state
@@ -108,7 +105,7 @@ symmetric role User:
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     users = bag()
     for i in range(NUM_USERS):
         users.add(User())
@@ -118,13 +115,13 @@ action Init:
 
 # R1: WIP limit is never exceeded.
 always assertion WipLimitRespected:
-    wip = len([c for c in db.cards if c.col == Column.InProgress])
+    wip = len([c for c in system.cards if c.col == Column.InProgress])
     return wip <= WIP_LIMIT
 
 # R2: Cards only move one column at a time (valid transitions).
 transition assertion ValidColumnTransitions(before, after):
-    for ac in after.db.cards:
-        for bc in before.db.cards:
+    for ac in after.system.cards:
+        for bc in before.system.cards:
             if ac.id == bc.id and ac.col != bc.col:
                 if bc.col == Column.Todo and ac.col != Column.InProgress:
                     return False
@@ -136,5 +133,5 @@ transition assertion ValidColumnTransitions(before, after):
 
 # R3: No duplicate card IDs.
 always assertion UniqueCardIds:
-    ids = [c.id for c in db.cards]
+    ids = [c.id for c in system.cards]
     return len(ids) == len(set(ids))

--- a/examples/requirements/lovable/05-store/Store.fizz
+++ b/examples/requirements/lovable/05-store/Store.fizz
@@ -25,7 +25,7 @@ ORDER_IDS = symmetry.nominal(name="order", limit=4)
 # products table: product_id -> stock (int)
 # orders table: list of records (order_id, product_id, buyer_id)
 
-role Server:
+role System:
     action Init:
         self.products = {}
         self.orders = []
@@ -49,16 +49,15 @@ symmetric role Buyer:
         self.my_orders = []
 
     atomic func RefreshView():
-        self.view_stock = db.products
-        self.my_orders = [o for o in db.orders if o.buyer == self.__id__]
+        self.view_stock = system.products
+        self.my_orders = [o for o in system.orders if o.buyer == self.__id__]
 
     atomic action BuyProduct:
         # Buyer sees items in stock
         available = [p for p in self.view_stock if self.view_stock[p] > 0]
-        require len(available) > 0
-        product = any available
+        product = oneof available
         order_id = ORDER_IDS.fresh()
-        db.Purchase(order_id, product, self.__id__)
+        system.Purchase(order_id, product, self.__id__)
         self.RefreshView()
 
     atomic fair action Refresh:
@@ -73,21 +72,20 @@ role Admin:
         pass
 
     atomic action Restock:
-        available_products = [p for p in db.products]
-        require len(available_products) > 0
-        product = any available_products
-        require db.products[product] < MAX_STOCK
-        db.Restock(product, 1)
+        available_products = [p for p in system.products]
+        product = oneof available_products
+        require system.products[product] < MAX_STOCK
+        system.Restock(product, 1)
 
 
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     # Create products with initial stock
     for i in range(NUM_PRODUCTS):
         pid = PRODUCTS.fresh()
-        db.products[pid] = 1
+        system.products[pid] = 1
     admin = Admin()
     buyers = bag()
     for i in range(NUM_BUYERS):
@@ -98,19 +96,19 @@ action Init:
 
 # R1: Stock never goes negative (no overselling).
 always assertion NoNegativeStock:
-    for p in db.products:
-        if db.products[p] < 0:
+    for p in system.products:
+        if system.products[p] < 0:
             return False
     return True
 
 # R2: Stock never exceeds MAX_STOCK.
 always assertion StockNotOverMax:
-    for p in db.products:
-        if db.products[p] > MAX_STOCK:
+    for p in system.products:
+        if system.products[p] > MAX_STOCK:
             return False
     return True
 
 # R3: Each order has a unique ID.
 always assertion UniqueOrderIds:
-    ids = [o.id for o in db.orders]
+    ids = [o.id for o in system.orders]
     return len(ids) == len(set(ids))

--- a/examples/requirements/lovable/06-doc-permissions/DocPermissions.fizz
+++ b/examples/requirements/lovable/06-doc-permissions/DocPermissions.fizz
@@ -25,7 +25,7 @@ Permission = enum("NoAccess", "Viewer", "Editor")
 # docs table: doc_id -> record(content, owner_id)
 # permissions table: {doc_id: {user_id: permission}}
 
-role Server:
+role System:
     action Init:
         self.docs = {}
         self.perms = {}
@@ -67,30 +67,26 @@ role Owner:
 
     atomic action CreateDoc:
         doc_id = DOC_IDS.fresh()
-        content = any CONTENT.choices()
-        db.CreateDoc(doc_id, "owner", content)
+        content = oneof CONTENT.choices()
+        system.CreateDoc(doc_id, "owner", content)
         self.my_docs = self.my_docs + [doc_id]
 
     atomic action EditDoc:
-        require len(self.my_docs) > 0
-        doc = any self.my_docs
-        new_content = any CONTENT.choices()
-        db.EditDoc(doc, "owner", new_content)
+        doc = oneof self.my_docs
+        new_content = oneof CONTENT.choices()
+        system.EditDoc(doc, "owner", new_content)
 
     atomic action GrantViewer:
-        require len(self.my_docs) > 0
-        doc = any self.my_docs
-        db.GrantPermission(doc, "owner", "collaborator", Permission.Viewer)
+        doc = oneof self.my_docs
+        system.GrantPermission(doc, "owner", "collaborator", Permission.Viewer)
 
     atomic action GrantEditor:
-        require len(self.my_docs) > 0
-        doc = any self.my_docs
-        db.GrantPermission(doc, "owner", "collaborator", Permission.Editor)
+        doc = oneof self.my_docs
+        system.GrantPermission(doc, "owner", "collaborator", Permission.Editor)
 
     atomic action RevokeAccess:
-        require len(self.my_docs) > 0
-        doc = any self.my_docs
-        db.RevokePermission(doc, "owner", "collaborator")
+        doc = oneof self.my_docs
+        system.RevokePermission(doc, "owner", "collaborator")
 
 
 # ─── Collaborator (the other user) ───────────────────────────────────
@@ -103,37 +99,35 @@ role Collaborator:
         self.cached_content = None
 
     atomic func RefreshView(doc_id):
-        if doc_id in db.perms and "collaborator" in db.perms[doc_id]:
-            self.cached_perm = db.perms[doc_id]["collaborator"]
+        if doc_id in system.perms and "collaborator" in system.perms[doc_id]:
+            self.cached_perm = system.perms[doc_id]["collaborator"]
         else:
             self.cached_perm = Permission.NoAccess
 
     atomic action TryRead:
-        require len(db.docs) > 0
-        doc = any db.docs.keys()
+        doc = oneof system.docs.keys()
         require self.cached_perm != Permission.NoAccess
-        content = db.ReadDoc(doc, "collaborator")
+        content = system.ReadDoc(doc, "collaborator")
         self.cached_content = content
         self.RefreshView(doc)
 
     atomic action TryEdit:
-        require len(db.docs) > 0
-        doc = any db.docs.keys()
+        doc = oneof system.docs.keys()
         require self.cached_perm == Permission.Editor
-        new_content = any CONTENT.choices()
-        db.EditDoc(doc, "collaborator", new_content)
+        new_content = oneof CONTENT.choices()
+        system.EditDoc(doc, "collaborator", new_content)
         self.RefreshView(doc)
 
     atomic fair action Refresh:
-        if len(db.docs) > 0:
-            doc = any db.docs.keys()
+        if len(system.docs) > 0:
+            doc = oneof system.docs.keys()
             self.RefreshView(doc)
 
 
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     owner = Owner()
     collaborator = Collaborator()
 
@@ -149,7 +143,7 @@ action Init:
 
 # R3: The owner always retains ownership of their documents.
 always assertion OwnerNeverLosesOwnership:
-    for doc_id in db.docs:
-        if db.docs[doc_id].owner != "owner":
+    for doc_id in system.docs:
+        if system.docs[doc_id].owner != "owner":
             return False
     return True

--- a/examples/requirements/lovable/07-approval/Approval.fizz
+++ b/examples/requirements/lovable/07-approval/Approval.fizz
@@ -24,7 +24,7 @@ Status = enum("Draft", "Submitted", "Approved", "Rejected")
 # ─── Server (Database) ───────────────────────────────────────────────
 # requests table: list of records (id, status)
 
-role Server:
+role System:
     action Init:
         self.requests = []
 
@@ -53,26 +53,24 @@ role Submitter:
         self.view = []
 
     atomic func RefreshView():
-        self.view = db.requests
+        self.view = system.requests
 
     atomic action CreateRequest:
         id = IDS.fresh()
-        db.CreateRequest(id)
+        system.CreateRequest(id)
         self.RefreshView()
 
     atomic action SubmitRequest:
         drafts = [r for r in self.view if r.status == Status.Draft]
-        require len(drafts) > 0
-        req = any drafts
-        db.UpdateStatus(req.id, Status.Draft, Status.Submitted)
+        req = oneof drafts
+        system.UpdateStatus(req.id, Status.Draft, Status.Submitted)
         self.RefreshView()
 
     atomic action ReviseAndResubmit:
         rejected = [r for r in self.view if r.status == Status.Rejected]
-        require len(rejected) > 0
-        req = any rejected
+        req = oneof rejected
         # Revise (back to Draft, then immediately Submit)
-        db.UpdateStatus(req.id, Status.Rejected, Status.Submitted)
+        system.UpdateStatus(req.id, Status.Rejected, Status.Submitted)
         self.RefreshView()
 
     atomic fair action Refresh:
@@ -87,20 +85,18 @@ role Approver:
         self.view = []
 
     atomic func RefreshView():
-        self.view = db.requests
+        self.view = system.requests
 
     atomic action ApproveRequest:
         pending = [r for r in self.view if r.status == Status.Submitted]
-        require len(pending) > 0
-        req = any pending
-        db.UpdateStatus(req.id, Status.Submitted, Status.Approved)
+        req = oneof pending
+        system.UpdateStatus(req.id, Status.Submitted, Status.Approved)
         self.RefreshView()
 
     atomic action RejectRequest:
         pending = [r for r in self.view if r.status == Status.Submitted]
-        require len(pending) > 0
-        req = any pending
-        db.UpdateStatus(req.id, Status.Submitted, Status.Rejected)
+        req = oneof pending
+        system.UpdateStatus(req.id, Status.Submitted, Status.Rejected)
         self.RefreshView()
 
     atomic fair action Refresh:
@@ -110,7 +106,7 @@ role Approver:
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     submitter = Submitter()
     approver = Approver()
 
@@ -122,10 +118,10 @@ action Init:
 #     Rejected -> Submitted (resubmit)
 #     No other transitions are possible.
 transition assertion ValidTransitions(before, after):
-    for i in range(len(after.db.requests)):
-        if i < len(before.db.requests):
-            old_status = before.db.requests[i].status
-            new_status = after.db.requests[i].status
+    for i in range(len(after.system.requests)):
+        if i < len(before.system.requests):
+            old_status = before.system.requests[i].status
+            new_status = after.system.requests[i].status
             if old_status != new_status:
                 # Check allowed transitions
                 if old_status == Status.Draft and new_status == Status.Submitted:
@@ -142,10 +138,10 @@ transition assertion ValidTransitions(before, after):
 
 # R2: Approved requests are final — they never change status.
 transition assertion ApprovedIsFinal(before, after):
-    for i in range(len(before.db.requests)):
-        if before.db.requests[i].status == Status.Approved:
-            if i >= len(after.db.requests):
+    for i in range(len(before.system.requests)):
+        if before.system.requests[i].status == Status.Approved:
+            if i >= len(after.system.requests):
                 return False
-            if after.db.requests[i].status != Status.Approved:
+            if after.system.requests[i].status != Status.Approved:
                 return False
     return True

--- a/examples/requirements/lovable/08-shopping-list/ShoppingList.fizz
+++ b/examples/requirements/lovable/08-shopping-list/ShoppingList.fizz
@@ -25,7 +25,7 @@ NAMES = symmetry.nominal(name="name", limit=2)
 # items table: list of records preserving insertion order
 # Each item: id, name, checked (bool), checked_by (user or "")
 
-role Server:
+role System:
     action Init:
         self.items = []
 
@@ -66,38 +66,35 @@ symmetric role User:
         self.view = []
 
     atomic func RefreshView():
-        self.view = db.items
+        self.view = system.items
 
     atomic action AddItem:
         id = IDS.fresh()
-        name = any NAMES.choices()
-        db.AddItem(id, name)
+        name = oneof NAMES.choices()
+        system.AddItem(id, name)
         self.RefreshView()
 
     atomic action CheckOffItem:
         unchecked = [item for item in self.view if not item.checked]
-        require len(unchecked) > 0
-        item = any unchecked
-        db.CheckOffItem(item.id, self.__id__)
+        item = oneof unchecked
+        system.CheckOffItem(item.id, self.__id__)
         self.RefreshView()
 
     atomic action UncheckItem:
         checked = [item for item in self.view if item.checked]
-        require len(checked) > 0
-        item = any checked
-        db.UncheckItem(item.id)
+        item = oneof checked
+        system.UncheckItem(item.id)
         self.RefreshView()
 
     atomic action RemoveItem:
-        require len(self.view) > 0
-        item = any self.view
-        db.RemoveItem(item.id)
+        item = oneof self.view
+        system.RemoveItem(item.id)
         self.RefreshView()
 
     atomic action ClearChecked:
         has_checked = len([item for item in self.view if item.checked]) > 0
         require has_checked
-        db.ClearChecked()
+        system.ClearChecked()
         self.RefreshView()
 
     atomic fair action Refresh:
@@ -107,7 +104,7 @@ symmetric role User:
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     users = bag()
     for i in range(NUM_USERS):
         users.add(User())
@@ -117,19 +114,19 @@ action Init:
 
 # R1: No duplicate item IDs.
 always assertion UniqueItemIds:
-    ids = [item.id for item in db.items]
+    ids = [item.id for item in system.items]
     return len(ids) == len(set(ids))
 
 # R2: A checked item records who checked it off.
 always assertion CheckedHasAuthor:
-    for item in db.items:
+    for item in system.items:
         if item.checked and item.checked_by == "":
             return False
     return True
 
 # R3: An unchecked item has no author.
 always assertion UncheckedHasNoAuthor:
-    for item in db.items:
+    for item in system.items:
         if not item.checked and item.checked_by != "":
             return False
     return True

--- a/examples/requirements/lovable/09-salon-booking/SalonBooking.fizz
+++ b/examples/requirements/lovable/09-salon-booking/SalonBooking.fizz
@@ -34,7 +34,7 @@ APPT_IDS = symmetry.nominal(name="appt", limit=MAX_APPTS)
 # slots table: slot_id -> employee_id (available, unbooked)
 # appointments table: list of record(id, slot, employee, customer)
 
-role Server:
+role System:
     action Init:
         self.employees = set()
         self.slots = {}
@@ -86,18 +86,16 @@ role Owner:
         require len(employees) < NUM_EMPLOYEES
         emp = Employee()
         employees.add(emp)
-        db.ActivateEmployee(emp.__id__)
+        system.ActivateEmployee(emp.__id__)
 
     atomic action RemoveEmployee:
-        require len(employees) > 0
-        emp = any employees
-        db.DeactivateEmployee(emp.__id__)
+        emp = oneof employees
+        system.DeactivateEmployee(emp.__id__)
         employees = bag([e for e in employees if e.__id__ != emp.__id__])
 
     atomic action CancelAnyAppointment:
-        require len(db.appointments) > 0
-        appt = any db.appointments
-        db.CancelAppointment(appt.id)
+        appt = oneof system.appointments
+        system.CancelAppointment(appt.id)
 
 
 # ─── Employee (Browser Session) ──────────────────────────────────────
@@ -110,33 +108,31 @@ symmetric role Employee:
         self.my_appts = []
 
     atomic func RefreshView():
-        self.view_slots = {sid: db.slots[sid] for sid in db.slots if db.slots[sid] == self.__id__}
-        self.my_appts = [a for a in db.appointments if a.employee == self.__id__]
+        self.view_slots = {sid: system.slots[sid] for sid in system.slots if system.slots[sid] == self.__id__}
+        self.my_appts = [a for a in system.appointments if a.employee == self.__id__]
 
     # Employee opens up a time slot on their schedule
     # Uses stale view: employee may try to add a slot after being fired
     atomic action AddSlot:
         slot_id = SLOT_IDS.fresh()
-        db.AddSlot(slot_id, self.__id__)
+        system.AddSlot(slot_id, self.__id__)
         self.RefreshView()
 
     # Employee removes one of their own available slots (from stale view)
     atomic action RemoveSlot:
-        require len(self.view_slots) > 0
-        slot = any self.view_slots.keys()
-        db.RemoveSlot(slot)
+        slot = oneof self.view_slots.keys()
+        system.RemoveSlot(slot)
         self.RefreshView()
 
     # Employee cancels one of their own appointments (from stale view)
     atomic action CancelOwnAppointment:
-        require len(self.my_appts) > 0
-        appt = any self.my_appts
-        db.CancelAppointment(appt.id)
+        appt = oneof self.my_appts
+        system.CancelAppointment(appt.id)
         self.RefreshView()
 
     # Employee refreshes to see latest schedule
     atomic fair action Refresh:
-        if self.__id__ in db.employees:
+        if self.__id__ in system.employees:
             self.RefreshView()
 
 
@@ -150,22 +146,20 @@ symmetric role Customer:
         self.my_appts = []
 
     atomic func RefreshView():
-        self.view_slots = db.slots
-        self.my_appts = [a for a in db.appointments if a.customer == self.__id__]
+        self.view_slots = system.slots
+        self.my_appts = [a for a in system.appointments if a.customer == self.__id__]
 
     # Customer picks an available slot and books it
     atomic action BookSlot:
-        require len(self.view_slots) > 0
-        slot = any self.view_slots.keys()
+        slot = oneof self.view_slots.keys()
         appt_id = APPT_IDS.fresh()
-        db.BookAppointment(appt_id, slot, self.__id__)
+        system.BookAppointment(appt_id, slot, self.__id__)
         self.RefreshView()
 
     # Customer cancels one of their own appointments
     atomic action CancelMyAppointment:
-        require len(self.my_appts) > 0
-        appt = any self.my_appts
-        db.CancelAppointment(appt.id)
+        appt = oneof self.my_appts
+        system.CancelAppointment(appt.id)
         self.RefreshView()
 
     # Customer refreshes to see latest availability
@@ -176,7 +170,7 @@ symmetric role Customer:
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     owner = Owner()
     employees = bag()
     customers = bag()
@@ -188,31 +182,31 @@ action Init:
 
 # R1: No double-booking — a slot appears in at most one appointment.
 always assertion NoDoubleBooking:
-    booked_slots = [a.slot for a in db.appointments]
+    booked_slots = [a.slot for a in system.appointments]
     return len(booked_slots) == len(set(booked_slots))
 
 # R2: A booked slot is never also listed as available.
 always assertion BookedNotAvailable:
-    for a in db.appointments:
-        if a.slot in db.slots:
+    for a in system.appointments:
+        if a.slot in system.slots:
             return False
     return True
 
 # R3: All appointments reference active employees.
 always assertion AppointmentsHaveActiveEmployee:
-    for a in db.appointments:
-        if a.employee not in db.employees:
+    for a in system.appointments:
+        if a.employee not in system.employees:
             return False
     return True
 
 # R4: All available slots belong to active employees.
 always assertion SlotsHaveActiveEmployee:
-    for sid in db.slots:
-        if db.slots[sid] not in db.employees:
+    for sid in system.slots:
+        if system.slots[sid] not in system.employees:
             return False
     return True
 
 # R5: Unique appointment IDs.
 always assertion UniqueAppointmentIds:
-    ids = [a.id for a in db.appointments]
+    ids = [a.id for a in system.appointments]
     return len(ids) == len(set(ids))

--- a/examples/requirements/lovable/10-salon-schedule/SalonSchedule.fizz
+++ b/examples/requirements/lovable/10-salon-schedule/SalonSchedule.fizz
@@ -44,7 +44,7 @@ APPT_IDS = symmetry.nominal(name="appt", limit=3)
 
 # ─── Server (Database) ───────────────────────────────────────────────
 
-role Server:
+role System:
     action Init:
         # schedule: set of encoded codes (dow * SLOTS_PER_DAY + slot)
         self.schedule = set()
@@ -78,8 +78,8 @@ role Employee:
         pass
 
     atomic action ToggleScheduleSlot:
-        schedule_code = any range(DAYS_IN_WEEK * SLOTS_PER_DAY)
-        db.ToggleSchedule(schedule_code)
+        schedule_code = oneof range(DAYS_IN_WEEK * SLOTS_PER_DAY)
+        system.ToggleSchedule(schedule_code)
 
 
 # ─── Customer (Human + Browser) ──────────────────────────────────────
@@ -94,20 +94,20 @@ symmetric role Customer:
         self.view_slots = [record(cal_day=clock_day + d, slot=s, dow_idx=(clock_dow + d) % DAYS_IN_WEEK)
             for d in range(BOOKING_WINDOW)
             for s in range(SLOTS_PER_DAY)
-            if (clock_dow + d) % DAYS_IN_WEEK * SLOTS_PER_DAY + s in db.schedule
+            if (clock_dow + d) % DAYS_IN_WEEK * SLOTS_PER_DAY + s in system.schedule
             if d > 0 or s + 1 > clock_phase
-            if all([not (a.cal_day == clock_day + d and a.slot == s) for a in db.appointments])]
-        self.my_appts = [a for a in db.appointments if a.customer == self.__id__]
+            if all([not (a.cal_day == clock_day + d and a.slot == s) for a in system.appointments])]
+        self.my_appts = [a for a in system.appointments if a.customer == self.__id__]
 
     atomic action BookSlot:
-        chosen = any self.view_slots
+        chosen = oneof self.view_slots
         appt_id = APPT_IDS.fresh()
-        db.BookAppointment(appt_id, chosen.cal_day, chosen.slot, chosen.dow_idx, self.__id__)
+        system.BookAppointment(appt_id, chosen.cal_day, chosen.slot, chosen.dow_idx, self.__id__)
         self.RefreshView()
 
     atomic action CancelMyAppointment:
-        appt = any [a for a in self.my_appts if a.cal_day > clock_day or (a.cal_day == clock_day and a.slot + 1 > clock_phase)]
-        db.CancelAppointment(appt.id)
+        appt = oneof [a for a in self.my_appts if a.cal_day > clock_day or (a.cal_day == clock_day and a.slot + 1 > clock_phase)]
+        system.CancelAppointment(appt.id)
         self.RefreshView()
 
     atomic fair action Refresh:
@@ -123,13 +123,13 @@ atomic fair action AdvanceClock:
         clock_day = clock_day + 1
         clock_dow = (clock_dow + 1) % DAYS_IN_WEEK
         clock_phase = 0
-        db.CleanupPast()
+        system.CleanupPast()
 
 
 # ─── Initialization ──────────────────────────────────────────────────
 
 action Init:
-    db = Server()
+    system = System()
     emp = Employee()
     customers = bag()
     for i in range(NUM_CUSTOMERS):
@@ -142,16 +142,16 @@ action Init:
 # ─── Safety Assertions ───────────────────────────────────────────────
 
 always assertion NoDoubleBooking:
-    for i in range(len(db.appointments)):
-        for j in range(i + 1, len(db.appointments)):
-            if db.appointments[i].cal_day == db.appointments[j].cal_day:
-                if db.appointments[i].slot == db.appointments[j].slot:
+    for i in range(len(system.appointments)):
+        for j in range(i + 1, len(system.appointments)):
+            if system.appointments[i].cal_day == system.appointments[j].cal_day:
+                if system.appointments[i].slot == system.appointments[j].slot:
                     return False
     return True
 
 # All appointments are in the future (past appointments get cleaned up).
 always assertion NoPastAppointments:
-    for a in db.appointments:
+    for a in system.appointments:
         if a.cal_day < clock_day:
             return False
     return True

--- a/examples/requirements/lovable/MODELING_GUIDE.md
+++ b/examples/requirements/lovable/MODELING_GUIDE.md
@@ -9,11 +9,11 @@ Guide for writing formal specifications of apps built with Lovable
 
 | Lovable Component | FizzBee Model |
 |:---|:---|
-| Supabase database | `role Server` (single instance, ground truth) |
+| Supabase database | `role System` (single instance, ground truth) |
 | User's browser | `role User` or `symmetric role Customer` (view + actions) |
 | React component state | `self.view_*` fields on user roles |
-| Supabase table row | Record in a list on the Server role |
-| Row-level security (RLS) | `require` guards in Server functions |
+| Supabase table row | Record in a list on the System role |
+| Row-level security (RLS) | `require` guards in System functions |
 | Supabase realtime | Not modeled — user refreshes manually (stale views) |
 
 ### Why Model Stale Views?
@@ -24,7 +24,7 @@ models this explicitly:
 
 1. **RefreshView**: Reads current database state into `self.view_*`
 2. **User action**: Reads from `self.view_*` (potentially stale)
-3. **Server function**: Validates against current database state with `require`
+3. **System function**: Validates against current database state with `require`
 
 This pattern catches race conditions where two users see the same slot
 as available but only one can book it.
@@ -43,7 +43,7 @@ options:
 # Constants and symmetry domains
 # ...
 
-role Server:
+role System:
     action Init:
         # Initialize database tables as lists/sets/dicts
     # Atomic functions for database operations (INSERT, UPDATE, DELETE)
@@ -53,16 +53,16 @@ symmetric role User:
     action Init:
         # Initialize view state
     atomic func RefreshView():
-        # Read from db.* into self.view_*
+        # Read from system.* into self.view_*
     atomic action SomeUserAction:
-        # Pick from self.view_*, call db.SomeOperation(), refresh view
+        # Pick from self.view_*, call system.SomeOperation(), refresh view
 
 # Clock (if time matters)
 atomic fair action AdvanceClock:
     # Advance time, clean up past data
 
 action Init:
-    db = Server()
+    system = System()
     users = bag()
     for i in range(NUM_USERS):
         users.add(User())
@@ -98,21 +98,21 @@ self.schedule.add(schedule_code)
 self.schedule.discard(schedule_code)
 ```
 
-### Stale View → Server Validation
+### Stale View → System Validation
 
 The core race condition pattern:
 
 ```python
 symmetric role Customer:
     atomic func RefreshView():
-        self.view_slots = [s for s in db.available_slots if is_valid(s)]
+        self.view_slots = [s for s in system.available_slots if is_valid(s)]
 
     atomic action BookSlot:
-        chosen = any self.view_slots          # Pick from stale view
-        db.BookSlot(chosen, self.__id__)      # Server validates
+        chosen = oneof self.view_slots          # Pick from stale view
+        system.BookSlot(chosen, self.__id__)      # System validates
         self.RefreshView()                     # Refresh after action
 
-role Server:
+role System:
     atomic func BookSlot(slot, customer_id):
         require slot in self.available_slots   # Might fail if stale
         self.available_slots.remove(slot)
@@ -132,11 +132,11 @@ role Owner:
     atomic action HireEmployee:
         emp = Employee()
         employees.add(emp)
-        db.ActivateEmployee(emp.__id__)
+        system.ActivateEmployee(emp.__id__)
 
     atomic action FireEmployee:
-        emp = any employees
-        db.DeactivateEmployee(emp.__id__)
+        emp = oneof employees
+        system.DeactivateEmployee(emp.__id__)
         employees = bag([e for e in employees if e.__id__ != emp.__id__])
 ```
 
@@ -160,7 +160,7 @@ atomic fair action AdvanceClock:
         clock_day = clock_day + 1
         clock_dow = (clock_dow + 1) % DAYS_IN_WEEK
         clock_phase = 0
-        db.CleanupPast()  # Free interval slots for garbage-collected data
+        system.CleanupPast()  # Free interval slots for garbage-collected data
 ```
 
 **Why `limit = BOOKING_WINDOW + 1`?** When `AdvanceClock` increments
@@ -187,10 +187,10 @@ Garbage-collect old records to free slots.
 
 ```python
 # CRASHES
-self.cached = db.ReadDoc(doc_id)
+self.cached = system.ReadDoc(doc_id)
 
 # WORKS
-content = db.ReadDoc(doc_id)
+content = system.ReadDoc(doc_id)
 self.cached = content
 ```
 
@@ -201,7 +201,7 @@ self.cached = content
 1. **List comprehensions over loops**: Each statement creates nodes.
    Collapse nested loops and if-chains into single comprehensions.
 
-2. **`any` blocks on empty**: No need for `require len(xs) > 0` before `any xs`.
+2. **`oneof` blocks on empty**: No need for `require len(xs) > 0` before `oneof xs`. (`any` is the deprecated alias for `oneof`.)
 
 3. **`require all([...])`** instead of for-loop with require.
 


### PR DESCRIPTION
- Rename `role Server` to `role System` across all 10 lovable specs
- Rename `db = Server()` to `system = System()` and all `db.` refs
- Replace deprecated `any` keyword with `oneof` throughout
- Remove redundant `require len(X) > 0` before `oneof X` (oneof on empty iterable disables the action automatically)
- Update MODELING_GUIDE.md with matching changes and prose

All 10 specs verified: identical Nodes/Valid Nodes/Unique states before and after the refactor.