### PR TITLE
fix(modelchecker): builtins must not shadow user-defined names

### DIFF
--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -654,8 +654,15 @@ func (p *Process) removeThread(threadIndex int) {
 // GetAllVariables returns all variables visible in the Current thread.
 // This includes state variables and variables from the Current thread's variables in the top call frame
 func (p *Process) GetAllVariables() starlark.StringDict {
-	// Shallow clone the globals
-	dict := maps.Clone(p.Heap.globals)
+	// Resolution precedence (Python-like, last write wins via maps.Copy):
+	// builtins < globals < state < self < locals/scope. Builtins seed the
+	// dict so any user-defined name (global, state, self, local) with the
+	// same spelling shadows them. Without this ordering, a global or local
+	// named `sum`, `bag`, `enum`, `record`, ... would be silently replaced
+	// by the matching builtin — see #340 (sum builtin) + the 11-04
+	// role-functions runtime panic that motivated this fix.
+	dict := maps.Clone(lib.Builtins)
+	maps.Copy(dict, p.Heap.globals)
 
 	roleRefs := make(map[starlark.Value]starlark.Value)
 	for _, role := range p.Roles {
@@ -673,7 +680,6 @@ func (p *Process) GetAllVariables() starlark.StringDict {
 	}
 	CopyDict(frame.vars, dict, roleRefs, nil, 0)
 	frame.scope.getAllVisibleVariablesResolveRoles(dict, roleRefs)
-	maps.Copy(dict, lib.Builtins)
 	dict["deepcopy"] = starlark.NewBuiltin("deepcopy", DeepCopyBuiltIn)
 	dict["resolve_role"] = lib.CreateResolveRoleBuiltIn(&p.Roles)
 	maps.Copy(dict, p.Modules)
@@ -691,8 +697,10 @@ func (p *Process) GetAllVariables() starlark.StringDict {
 // GetAllVariablesNocopy returns all variables visible in the Current thread, without deep copying.
 // This includes state variables and variables from the Current thread's variables in the top call frame
 func (p *Process) GetAllVariablesNocopy() starlark.StringDict {
-	// Shallow clone the globals
-	dict := maps.Clone(p.Heap.globals)
+	// Resolution precedence: builtins < globals < state < self < locals.
+	// See GetAllVariables for the full rationale.
+	dict := maps.Clone(lib.Builtins)
+	maps.Copy(dict, p.Heap.globals)
 
 	maps.Copy(dict, p.Heap.state)
 	frame := p.currentThread().currentFrame()
@@ -702,7 +710,6 @@ func (p *Process) GetAllVariablesNocopy() starlark.StringDict {
 	maps.Copy(dict, frame.vars)
 	frame.scope.getAllVisibleVariablesToDictNoCopy(dict)
 
-	maps.Copy(dict, lib.Builtins)
 	dict["deepcopy"] = starlark.NewBuiltin("deepcopy", DeepCopyBuiltIn)
 	dict["resolve_role"] = lib.CreateResolveRoleBuiltIn(&p.Roles)
 	maps.Copy(dict, p.Modules)


### PR DESCRIPTION
GetAllVariables and GetAllVariablesNocopy were inserting lib.Builtins into the resolution dict AFTER state, self, frame.vars, and scope vars. maps.Copy overwrites existing keys, so a local variable named after a builtin (sum, bag, enum, record, math, struct, symmetry, ...) was silently replaced by the builtin function — backwards from Python-like resolution, where locals shadow builtins.

The regression manifested with #340 (sum builtin) on examples/references/11-04-role-functions: the spec uses `sum = self.add(2, 3)` then passes `sum` to another method, but `sum` resolved to the builtin function, producing
`unknown binary op: int + builtin_function_or_method`.

Fix: insert lib.Builtins right after the globals clone, before any of state/self/locals/scope, so user code shadows the builtins. deepcopy/resolve_role/p.Modules and the role/Channel inserts remain where they are; they are added under controlled names that aren't likely to collide, and reordering them is a separate concern.

Verified: 11-04-role-functions runs to completion (Nodes: 6, Valid Nodes: 6, Unique states: 6, PASSED). Reference suite: 89/94 pass (one more than baseline). The remaining 5 failures are the unrelated ef25c33 baseline-drift bug fixed on a separate branch.