### PR TITLE
fix(modelchecker): restore Name ordering at yield, add IsYield flag

### DIFF
--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -176,6 +176,16 @@ type Process struct {
 	Enabled        bool `json:"-"`
 	ThreadProgress bool `json:"-"`
 
+	// IsYield: true when this process is at a yield boundary. Set in
+	// processNode-at-yield BEFORE calling YieldNode/YieldFork so the
+	// trace-extend boundary check (ShouldScheduleNode -> IsYieldNode)
+	// sees the yield label without polluting Process.Name. Process.Name
+	// gets set to "yield" AFTER scheduling (restoring pre-ef25c33 order)
+	// so child processes created by Fork() inherit the parent's previous
+	// (action) Name instead of "yield" — see #345 follow-up to ef25c33.
+	// Not propagated by Fork(): children start with IsYield=false.
+	IsYield bool `json:"-"`
+
 	Roles    []*lib.Role          `json:"roles"`
 	Channels map[int]*lib.Channel `json:"channels"`
 
@@ -307,6 +317,9 @@ func (p *Process) GetThreadsCount() int {
 func (p *Process) IsYieldNode() bool {
 	if p == nil {
 		return false
+	}
+	if p.IsYield {
+		return true
 	}
 	switch p.Name {
 	case "yield", "crash", "init":
@@ -1925,18 +1938,25 @@ func (p *Processor) processNode(node *Node) (bool, bool) {
 	}
 
 	if yield {
-		// Mark this node as a yield BEFORE scheduling its successors. The
-		// trace-extend yield-aware boundary check in ShouldScheduleNode reads
-		// parent.Process.IsYieldNode(), which depends on Name being set; if we
-		// scheduled first and labelled later, every successor would see a
-		// non-yield parent and the extension would never bound.
-		node.Name = "yield"
+		// Mark this node as a yield BEFORE scheduling so the trace-extend
+		// yield-aware boundary check in ShouldScheduleNode (which reads
+		// parent.Process.IsYieldNode()) sees the right answer. We set the
+		// IsYield flag rather than overwriting Name here because Name gets
+		// inherited via Process.Fork() into the children scheduled below;
+		// pre-ef25c33 children inherited the previous (action) Name, and
+		// downstream code (notably markovchain's yieldsCount) relies on
+		// only true yield-points carrying Name == "yield". Name is set
+		// AFTER scheduling, restoring pre-ef25c33 ordering for the Name
+		// label while keeping ef25c33's trace-extend fix via IsYield.
+		node.Process.IsYield = true
 
 		// In OLD mode this immediately schedules successor action-starts. In
 		// NEW (experimentalProcessedQueue) mode it instead saves the forks
 		// onto the node and queues the yield-point itself for later
 		// expansion by startProcessedQueue.
 		p.publishYieldPoint(node, forks)
+
+		node.Name = "yield"
 
 		if p.shouldThreadCrash(node) {
 			p.crashThread(node)


### PR DESCRIPTION
Commit ef25c33 ("trace: yield-aware boundary") moved node.Name = "yield" from AFTER YieldNode/YieldFork to BEFORE, so ShouldScheduleNode's parent.IsYieldNode() check would see the right label during trace-extend. The reordering had a side effect: Process.Fork() copies the parent's Name into each forked child, so thread-continuation and channel-message children scheduled inside YieldNode/scheduleChannelMessages started inheriting Name == "yield" instead of the parent's previous (action) Name.

Downstream code keys off Name == "yield" — notably markovchain's yieldsCount, which is reported as "Unique states" — so this inflated the user-visible state count on every spec whose actions yield mid-body (non-atomic actions, oneof blocks, parallel/serial for, cross-role calls). Six reference baselines drifted as a result.

Fix: separate the two roles Name overloaded:

- Add IsYield bool on Process, set BEFORE publishYieldPoint. This is the "is this a yield boundary?" signal trace-extend needs. It is NOT copied by Fork() (no entry in the struct literal), so child processes start with IsYield=false.
- Move node.Name = "yield" back to AFTER publishYieldPoint, restoring pre-ef25c33 ordering. Children created via Fork during scheduling inherit the parent's previous (action) Name as before.
- IsYieldNode() now returns true if IsYield OR Name in {yield, init, crash}, preserving every existing call site.

Test results: 5 of 6 drifted reference specs return to their baselines (04-03-for-loop-parallel, 12-05-error-handling-pattern, 13-02-01-two-phase-commit, 13-03-02-leader-election, 14-03-role-crash-ephemeral). The 6th (11-04-role-functions) was already failing with a Starlark runtime panic before this branch and is unrelated.

Slatedb-gc-boundary spec under both default and
--experimental_processed_queue paths gives identical state counts before and after, confirming this fix doesn't perturb either path's dedup behavior on a yield-heavy spec.