### PR TITLE
docs: document --experimental_processed_queue + DFS bound caveat

### DIFF
--- a/.claude/skills/fizz-check/SKILL.md
+++ b/.claude/skills/fizz-check/SKILL.md
@@ -39,6 +39,7 @@ Note: `fizz` is the installed binary. If building from source, use `./fizz` (wra
 | `--preinit-hook-file FILE` | — | Load preinit hook from `.cfg` file |
 | `--output-dir DIR` | auto-timestamped | Where to write output |
 | `--no-copy-ast` | off | Don't copy AST to output dir |
+| `--experimental_processed_queue` | off | EXPERIMENTAL: queue holds processed yield-points instead of unprocessed action-starts. Dedupes successors before they enter the queue → smaller peak queue memory (~10× on BFS, ~3× on DFS). State space and assertion outcomes unchanged under BFS. **Under DFS / Random with `max_actions` set, exploration order differs and may visit a different subset within the bound** — see Gotchas. |
 
 ---
 
@@ -197,6 +198,7 @@ NUM_SERVERS=10" spec.fizz
 ## Gotchas
 
 - **DFS / Random + `max_actions` is not exhaustive.** A `max_actions` cap (global or per-action in frontmatter) prunes paths past the limit. With BFS the bounded prefix is fully covered; with DFS / Random the cap interacts with the traversal order, so reachable states within the limit may still be missed. If you need exhaustive coverage with a cap, use BFS.
+- **`--experimental_processed_queue` shifts DFS/Random exploration order.** The flag dedupes successors before enqueue, which changes the order siblings are visited (drains them before descending). Under BFS this is purely a memory-layout change — same nodes, same unique-state count. Under DFS / Random, combined with a `max_actions` cap, the changed order can prune a *different* subset of reachable states than the existing path would. Without the cap (or with `max_actions` raised above the spec's natural diameter), both paths converge to the same canonical state set. If you compare baselines across the flag, set `max_actions` high enough that the bound never bites.
 - **`exists` assertions are disabled in simulation mode.** Simulation checks individual execution traces only; `exists` requires evaluating branches across the state graph.
 - **Simulation traces are not minimal.** Simulation produces *a* failing path, not the *shortest* one. Once you have a failing seed, narrow the bug with a guided `--trace` or model-check a smaller config to get a minimal counterexample.
 - **Random-seed simulation: passing ≠ correct.** "Passed across 1000 seeds" raises confidence but is not a proof. For correctness claims, model-check.

--- a/main.go
+++ b/main.go
@@ -892,7 +892,7 @@ func parseFlags() []string {
 	flag.IntVar(&traceExtend, "trace-extend", 0, "After trace ends, explore this many additional action depths (0 = stop at trace end)")
 	flag.StringVar(&preinitHook, "preinit-hook", "", "Starlark code as a string to execute after preinit but before freezing globals (multiline supported)")
 	flag.BoolVar(&isTest, "test", false, "Testing mode (prevents printing timestamps and other non-deterministic behavior. Default=false")
-	flag.BoolVar(&experimentalProcessedQueue, "experimental_processed_queue", false, "EXPERIMENTAL: BFS variant where the queue holds processed (yield-point) nodes instead of unprocessed action-starts. Dedupes successors before they enter the queue, reducing peak queue memory. Default=false (use existing path).")
+	flag.BoolVar(&experimentalProcessedQueue, "experimental_processed_queue", false, "EXPERIMENTAL: queue holds processed (yield-point) nodes instead of unprocessed action-starts. Dedupes successors before they enter the queue, reducing peak queue memory (~10x on BFS, ~3x on DFS). State space and assertion outcomes are identical under BFS. Under DFS/Random combined with max_actions, the changed exploration order may prune a different subset of states than the default path within the bound — raise max_actions above the spec's natural diameter to avoid the divergence. Default=false.")
 	flag.Parse()
 
 	// Validate that both file and string versions are not provided


### PR DESCRIPTION
Two parallel updates:

- main.go flag help: explain the memory benefit (~10x BFS, ~3x DFS), note that BFS state counts are identical to the default path, and call out the DFS/Random + max_actions divergence with the workaround (raise max_actions above the spec's natural diameter).

- .claude/skills/fizz-check/SKILL.md: add the flag to the All Flags table and extend the Gotchas section with a dedicated entry covering why the divergence happens and how to compare baselines across the flag.

Background: a 3-writer SlateDB GC boundary spec at max_actions=40 returned 86,865 unique states under DFS+experimental vs 111,134 under DFS+default. Raising max_actions to 1000 brought both to 111,134 — the NEW path's "drain siblings before descending" exploration order was hitting the depth cap from different paths than the default DFS. Same canonical state set when the cap doesn't bite.