### PR TITLE
feat(modelchecker): early deadlock detection in --experimental_proces…

### DIFF
--- a/main.go
+++ b/main.go
@@ -604,6 +604,18 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 		runs++
 		lastRootNode = rootNode
 
+		// Early deadlock detection (NEW path only): startProcessedQueue
+		// aborts the run on the first detected deadlock and exposes it
+		// here. Report and exit before any post-run graph traversal — no
+		// point doing the rest of the work, and dumpFailedNode reads
+		// node.Inbound which is still populated for this node.
+		if earlyDead := p1.GetEarlyDeadlock(); earlyDead != nil && !simulation {
+			fmt.Println("DEADLOCK detected (early)")
+			fmt.Println("FAILED: Model checker failed")
+			dumpFailedNode(sourceFileName, earlyDead, rootNode, outDir)
+			return nil
+		}
+
 		if !simulation {
 			if writeDotFileIfNeeded(p1, rootNode, outDir) {
 				return nil

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -1115,6 +1115,30 @@ type Processor struct {
 	// peakPendingActionStarts: maximum observed length of pendingActionStarts
 	// in NEW mode. Always 0 in OLD mode. Reported in the run summary.
 	peakPendingActionStarts int
+
+	// earlyDeadlock: in NEW mode with deadlock_detection enabled, set to
+	// the first yield-point whose expansion produced zero successors
+	// (and is not at the actionDepth bound). startProcessedQueue aborts
+	// the run when this is set; main.go reports it as a deadlock.
+	// nil otherwise.
+	earlyDeadlock *Node
+
+	// dedupHitsInExpansion: incremented every time processNode short-
+	// circuits on a findVisitedSymmetric dedup hit. Reset at the start of
+	// each Phase-2 yp expansion in startProcessedQueue. Used by the
+	// early-deadlock check: a yp whose expansion ALSO produced no new
+	// yps in p.queue AND had zero dedup hits genuinely has no live
+	// successors. (A dedup hit means the action-start reached a previously
+	// visited state — a live transition that wouldn't grow the queue.)
+	dedupHitsInExpansion int
+}
+
+// GetEarlyDeadlock returns the first deadlocked yield-point detected during
+// the run, or nil if none was found / detection is disabled / not in NEW
+// mode. A non-nil result means the model checker aborted exploration on
+// finding the deadlock rather than running to queue-exhaustion.
+func (p *Processor) GetEarlyDeadlock() *Node {
+	return p.earlyDeadlock
 }
 
 // SetExperimentalProcessedQueue switches the processor to the experimental
@@ -1490,8 +1514,33 @@ func (p *Processor) startProcessedQueue() (init *Node, failedNode *Node, err err
 		// yieldForks no longer needed; release for GC.
 		yp.yieldForks = nil
 
+		// Snapshot signals before expansion so we can tell after
+		// drainAndFlush whether yp produced any live successors:
+		//   1. queue length grew — new yield-points were enqueued.
+		//   2. dedupHitsInExpansion grew — action-starts reached
+		//      already-visited canonical states (no queue growth but a
+		//      real transition out of yp).
+		// Both must be zero to flag yp as a deadlock.
+		queueLenBefore := p.queue.Len()
+		p.dedupHitsInExpansion = 0
+
 		earlyReturn, failedNode = p.drainAndFlush(startTime, &prevCount, failedNode)
 		if earlyReturn {
+			p.printRunSummary(startTime)
+			return p.Init, failedNode, err
+		}
+
+		// Early deadlock detection: no new yield-points enqueued AND no
+		// dedup hits from yp's expansion AND not at the actionDepth bound.
+		// The OLD path detects this post-run by walking the graph
+		// (markovchain.go); here we have the signal at hand and fast-fail.
+		if p.config.GetDeadlockDetection() &&
+			p.queue.Len() == queueLenBefore &&
+			p.dedupHitsInExpansion == 0 &&
+			yp.actionDepth < int(p.config.Options.MaxActions) {
+			if p.earlyDeadlock == nil {
+				p.earlyDeadlock = yp
+			}
 			p.printRunSummary(startTime)
 			return p.Init, failedNode, err
 		}
@@ -1905,6 +1954,12 @@ func (p *Processor) processNode(node *Node) (bool, bool) {
 				}
 			}
 			node.Duplicate(other, yield)
+			// Count this as a "live successor" signal for the early
+			// deadlock detector in startProcessedQueue Phase 2. A dedup
+			// hit means an action-start reached a previously visited
+			// canonical state — a real transition out of the current yp,
+			// even though no new entry is added to p.queue.
+			p.dedupHitsInExpansion++
 			return false, false
 		} else {
 			node.Attach()


### PR DESCRIPTION
…sed_queue mode

In the default path, deadlock detection runs post-model-check: markovchain's traverseBFS walks the explored graph to find yield-points with no live descendants. This means the entire state space is explored before any deadlock is reported — wasted time when a deadlock is reachable early.

The experimental processed-queue path already pops each yield-point yp explicitly, schedules its successors, and drains them into new yield-points pushed onto p.queue. The signal "yp has no live successors" falls out for free: if the queue length is unchanged after drainAndFlush and yp.actionDepth < MaxActions, yp is a deadlock.

When detected, the run aborts fast and main.go reports the deadlock the same way the post-run path would (DEADLOCK detected + dumpFailedNode). Adds a small "(early)" suffix to the message so it's clear which path fired.

Behavior change:
  - Only active in --experimental_processed_queue mode (the OLD path is unchanged: still relies on traverseBFS).
  - Fast-fails on the first detected deadlock instead of running to queue-exhaustion. Subsequent deadlocks are not enumerated.
  - Respects spec's deadlock_detection setting (default false) — the check is a no-op when detection is disabled.

Verified: 94/94 reference specs pass. Hand-tested deadlock spec correctly reports "DEADLOCK detected (early)" under the flag; OLD path on the same spec produces the existing "DEADLOCK detected" output.

Independent of any planned --experimental_no_graph work — that landing will rely on this early detection since the no-graph mode has no graph for post-run traverseBFS to walk.