### PR TITLE
fix(main): preserve per-run dot output under --simulation_first_traces

### DIFF
--- a/main.go
+++ b/main.go
@@ -737,11 +737,16 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 		}
 
 		if !simulation && !experimentalNoGraph {
-			if writeDotFileIfNeeded(p1, rootNode, outDir) {
+			if writeDotFileIfNeeded(p1, rootNode, outDir, "graph.dot") {
 				return nil
 			}
 		} else if i <= simFirstTraces {
-			writeDotFileIfNeeded(p1, rootNode, outDir)
+			// One file per captured run so the first N traces are
+			// preserved instead of overwriting each other on a shared
+			// graph.dot path. The "last run" still lands at graph.dot
+			// below (line 903) so existing tooling reading that canonical
+			// name keeps working.
+			writeDotFileIfNeeded(p1, rootNode, outDir, fmt.Sprintf("graph_run_%d.dot", i))
 		}
 
 		if err != nil {
@@ -899,9 +904,12 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 		if runs-simFirstTraces > 1 {
 			fmt.Println("Not printing intermediate traces (only the last trace is shown)")
 		}
-		if runs > simFirstTraces {
-			writeDotFileIfNeeded(p1, lastRootNode, outDir)
-		}
+		// Always write the canonical graph.dot so downstream tooling
+		// (skills/scripts/docs that grep `out/*/graph.dot`) finds it
+		// even when --simulation_first_traces >= runs. When the last
+		// run was also captured as graph_run_<runs>.dot, this is a
+		// duplicate write — same content under the canonical name.
+		writeDotFileIfNeeded(p1, lastRootNode, outDir, "graph.dot")
 	}
 	return nil
 }
@@ -935,10 +943,15 @@ func printTraceAndExit(err error) {
 	os.Exit(1)
 }
 
-func writeDotFileIfNeeded(p1 *modelchecker.Processor, rootNode *modelchecker.Node, outDir string) bool {
+// writeDotFileIfNeeded writes the graph .dot file for the given root node
+// to outDir/fileName when the visited-node count is small enough to be
+// useful. fileName lets callers separate per-run outputs in simulation
+// mode (graph_run_1.dot, graph_run_2.dot, …) from the canonical
+// "last result" graph.dot used by the model-check path.
+func writeDotFileIfNeeded(p1 *modelchecker.Processor, rootNode *modelchecker.Node, outDir string, fileName string) bool {
 	if p1.GetVisitedNodesCount() < 250 || (simulation && p1.GetVisitedNodesCount() < 1000) {
 		dotString := modelchecker.GenerateDotFile(rootNode, make(map[*modelchecker.Node]bool))
-		dotFileName := filepath.Join(outDir, "graph.dot")
+		dotFileName := filepath.Join(outDir, fileName)
 		// Write the content to the file
 		err := os.WriteFile(dotFileName, []byte(dotString), 0644)
 		if err != nil {


### PR DESCRIPTION
Each captured run wrote to a shared `outDir/graph.dot` path, so all but the last overwrite silently. Only the final write survived and the flag's intent — capture the first N runs as separate samples — was unreachable. Reproduced on the salon spec with `--max_runs 1000 --simulation_first_traces 5`: five "Writen graph dotfile" log lines all pointed at the same path and the on-disk content was the fifth run only.

Thread a fileName argument through writeDotFileIfNeeded:
  - non-simulation call site keeps "graph.dot" (unchanged behavior)
  - simulation in-loop site uses "graph_run_<i>.dot" so the first N runs land in distinct files
  - post-loop "last run" write keeps the canonical "graph.dot" name so any downstream tooling reading the well-known path keeps working

Backward compatible: anything that consumed `graph.dot` keeps finding it (the post-loop write now fires unconditionally in simulation mode, including the edge case where --max_runs <= --simulation_first_traces and the canonical name would otherwise not exist). New consumers can also read `graph_run_*.dot` for the captured first-N samples.

Verified on the salon spec for both `--max_runs 5
--simulation_first_traces 5` (regression case, all 5 captures + graph.dot) and `--max_runs 1000 --simulation_first_traces 5` (5 captures + graph.dot from a non-captured later run).