### PR TITLE
feat(modelchecker): next_states() builtin for one-step ENABLED assert…

### DIFF
--- a/examples/references/09-06-next-states-restorable/RestoreAny.fizz
+++ b/examples/references/09-06-next-states-restorable/RestoreAny.fizz
@@ -1,0 +1,34 @@
+---
+deadlock_detection: false
+options:
+    max_actions: 8
+---
+
+# Soft-delete CRUDL: any trashed item can be restored directly.
+# EveryTrashItemRestorable must PASS.
+
+NUM_ITEMS = 3
+
+action Init:
+    items = {}
+    next_id = 0
+
+atomic action Create:
+    require next_id < NUM_ITEMS
+    items[next_id] = "active"
+    next_id += 1
+
+atomic action Delete:
+    id = oneof [k for k in items if items[k] == "active"]
+    items[id] = "trash"
+
+atomic action Restore:
+    id = oneof [k for k in items if items[k] == "trash"]
+    items[id] = "active"
+
+always assertion EveryTrashItemRestorable:
+    for k in items:
+        if items[k] == "trash":
+            if len([n for n in next_states() if n.state.items[k] == "active"]) == 0:
+                return False
+    return True

--- a/examples/references/09-06-next-states-restorable/baseline.txt
+++ b/examples/references/09-06-next-states-restorable/baseline.txt
@@ -1,0 +1,14 @@
+Model checking examples/references/09-06-next-states-restorable/RestoreAny.json
+configFileName: examples/references/09-06-next-states-restorable/fizz.yaml
+fizz.yaml not found. Using default options
+StateSpaceOptions: options:{max_actions:8  max_concurrent_actions:2}  deadlock_detection:false
+Nodes: 37, queued: 0, elapsed: 2.765625ms
+Time taken for model checking: 2.790833ms
+Writen graph dotfile: examples/references/09-06-next-states-restorable/out/run_2026-07-06_15-10-39/graph.dot
+To generate svg, run: 
+dot -Tsvg examples/references/09-06-next-states-restorable/out/run_2026-07-06_15-10-39/graph.dot -o graph.svg && open graph.svg
+Valid Nodes: 37 Unique states: 15
+IsLive: true
+Time taken to check liveness: 522.667µs
+PASSED: Model checker completed successfully
+Writen 1 node files and 1 link files to dir examples/references/09-06-next-states-restorable/out/run_2026-07-06_15-10-39

--- a/examples/references/09-07-next-states-violation/RestoreStack.fizz
+++ b/examples/references/09-07-next-states-violation/RestoreStack.fizz
@@ -1,0 +1,41 @@
+---
+deadlock_detection: false
+options:
+    max_actions: 8
+---
+
+# Soft-delete CRUDL where the trash is a STACK: only the most recently
+# deleted item can be restored. With two items in the trash, the bottom
+# one is not restorable in one step, so EveryTrashItemRestorable must
+# FAIL. This is the case a global-reachability (`exists`) formulation
+# cannot catch.
+
+NUM_ITEMS = 3
+
+action Init:
+    items = {}
+    trash_stack = []
+    next_id = 0
+
+atomic action Create:
+    require next_id < NUM_ITEMS
+    items[next_id] = "active"
+    next_id += 1
+
+atomic action Delete:
+    id = oneof [k for k in items if items[k] == "active"]
+    items[id] = "trash"
+    trash_stack = trash_stack + [id]
+
+atomic action Restore:
+    require len(trash_stack) > 0
+    id = trash_stack[-1]
+    trash_stack = trash_stack[:-1]
+    items[id] = "active"
+
+always assertion EveryTrashItemRestorable:
+    for k in items:
+        if items[k] == "trash":
+            if len([n for n in next_states() if n.state.items[k] == "active"]) == 0:
+                return False
+    return True

--- a/examples/references/09-07-next-states-violation/baseline.txt
+++ b/examples/references/09-07-next-states-violation/baseline.txt
@@ -1,0 +1,46 @@
+Model checking examples/references/09-07-next-states-violation/RestoreStack.json
+configFileName: examples/references/09-07-next-states-violation/fizz.yaml
+fizz.yaml not found. Using default options
+StateSpaceOptions: options:{max_actions:8  max_concurrent_actions:2}  deadlock_detection:false
+Nodes: 15, queued: 13, elapsed: 1.505375ms
+Time taken for model checking: 1.514417ms
+Writen graph dotfile: examples/references/09-07-next-states-violation/out/run_2026-07-06_15-10-39/graph.dot
+To generate svg, run: 
+dot -Tsvg examples/references/09-07-next-states-violation/out/run_2026-07-06_15-10-39/graph.dot -o graph.svg && open graph.svg
+FAILED: Model checker failed. Invariant:  EveryTrashItemRestorable
+------
+Init
+--
+state: {"items":{},"next_id":0,"trash_stack":[]}
+------
+Create
+--
+state: {"items":{"0":"active"},"next_id":1,"trash_stack":[]}
+------
+Create
+--
+state: {"items":{"0":"active","1":"active"},"next_id":2,"trash_stack":[]}
+------
+Delete
+--
+state: {"items":{"0":"active","1":"active"},"next_id":2,"trash_stack":[]}
+------
+Any:id=0
+--
+state: {"items":{"0":"trash","1":"active"},"next_id":2,"trash_stack":[0]}
+------
+Delete
+--
+state: {"items":{"0":"trash","1":"active"},"next_id":2,"trash_stack":[0]}
+------
+Any:id=1
+--
+state: {"items":{"0":"trash","1":"trash"},"next_id":2,"trash_stack":[0,1]}
+------
+Writen graph json: examples/references/09-07-next-states-violation/out/run_2026-07-06_15-10-39/error-graph.json
+Writen graph dotfile: examples/references/09-07-next-states-violation/out/run_2026-07-06_15-10-39/error-graph.dot
+To generate an image file, run: 
+dot -Tsvg examples/references/09-07-next-states-violation/out/run_2026-07-06_15-10-39/error-graph.dot -o error-graph.svg && open error-graph.svg
+Writen error states as html: examples/references/09-07-next-states-violation/out/run_2026-07-06_15-10-39/error-states.html
+To open: 
+open examples/references/09-07-next-states-violation/out/run_2026-07-06_15-10-39/error-states.html

--- a/examples/references/09-08-next-states-concurrency-cap/CapFalsePositive.fizz
+++ b/examples/references/09-08-next-states-concurrency-cap/CapFalsePositive.fizz
@@ -1,0 +1,33 @@
+---
+deadlock_detection: false
+options:
+    max_actions: 6
+    max_concurrent_actions: 1
+---
+
+# Regression guard for the concurrency-cap false positive: Churn is a
+# serial (non-atomic) action. At its mid-action yield, the one in-flight
+# thread exhausts max_concurrent_actions=1, so the real explorer cannot
+# schedule Restore from that state. The next_states() probe must ignore
+# the cap (ENABLED is a property of the state, not the scheduler), so
+# TrashRestorable must PASS. If the probe respected the cap, this spec
+# would FAIL at every mid-Churn yield.
+
+action Init:
+    items = {0: "trash"}
+    counter = 0
+
+action Churn:
+    counter = counter + 1
+    counter = counter + 1
+
+atomic action Restore:
+    id = oneof [k for k in items if items[k] == "trash"]
+    items[id] = "active"
+
+always assertion TrashRestorable:
+    for k in items:
+        if items[k] == "trash":
+            if len([n for n in next_states() if n.state.items[k] == "active"]) == 0:
+                return False
+    return True

--- a/examples/references/09-08-next-states-concurrency-cap/baseline.txt
+++ b/examples/references/09-08-next-states-concurrency-cap/baseline.txt
@@ -1,0 +1,14 @@
+Model checking examples/references/09-08-next-states-concurrency-cap/CapFalsePositive.json
+configFileName: examples/references/09-08-next-states-concurrency-cap/fizz.yaml
+fizz.yaml not found. Using default options
+StateSpaceOptions: options:{max_actions:6  max_concurrent_actions:1}  deadlock_detection:false
+Nodes: 55, queued: 0, elapsed: 3.758625ms
+Time taken for model checking: 3.777541ms
+Writen graph dotfile: examples/references/09-08-next-states-concurrency-cap/out/run_2026-07-06_15-10-40/graph.dot
+To generate svg, run: 
+dot -Tsvg examples/references/09-08-next-states-concurrency-cap/out/run_2026-07-06_15-10-40/graph.dot -o graph.svg && open graph.svg
+Valid Nodes: 55 Unique states: 43
+IsLive: true
+Time taken to check liveness: 980.459µs
+PASSED: Model checker completed successfully
+Writen 1 node files and 1 link files to dir examples/references/09-08-next-states-concurrency-cap/out/run_2026-07-06_15-10-40

--- a/examples/references/09-09-next-states-role-id/RoleIdMatch.fizz
+++ b/examples/references/09-09-next-states-role-id/RoleIdMatch.fizz
@@ -1,0 +1,46 @@
+---
+deadlock_detection: false
+options:
+    max_actions: 6
+---
+
+# next_states() with symmetric roles: transitions carry structured fields
+# (kind, role_ref, role_id, action_name) alongside the flat name. role_id
+# is the role's identity value (same as the role's __id__) and compares by
+# VALUE, so `n.role_id == w.__id__` works across the assertion/probe clone
+# boundary. Comparing Role objects directly would silently be False —
+# roles compare by pointer. See GOTCHAS.
+# (The fields are named action_name/role_ref because `action` and `role`
+# are fizz keywords and cannot appear as attribute names.)
+#
+# Also exercises the id component attrs: id.name ("Worker") and id.index.
+
+NUM_WORKERS = 2
+
+symmetric role Worker:
+    action Init:
+        self.status = "idle"
+
+    atomic action Work:
+        require self.status == "idle"
+        self.status = "done"
+
+action Init:
+    workers = bag()
+    for i in range(NUM_WORKERS):
+        workers.add(Worker())
+
+always assertion EveryIdleWorkerCanWork:
+    for w in workers:
+        if w.status == "idle":
+            witnesses = [n for n in next_states() if n.kind == "action" and n.action_name == "Work" and n.role_id == w.__id__]
+            # Exactly one: each worker has exactly one Work transition of its
+            # own. If role_id failed to discriminate between instances, both
+            # workers' transitions would match and this would be 2.
+            if len(witnesses) != 1:
+                return False
+            if w.__id__.name != "Worker":
+                return False
+            if w.__id__.index < 0:
+                return False
+    return True

--- a/examples/references/09-09-next-states-role-id/baseline.txt
+++ b/examples/references/09-09-next-states-role-id/baseline.txt
@@ -1,0 +1,17 @@
+Model checking examples/references/09-09-next-states-role-id/RoleIdMatch.json
+configFileName: examples/references/09-09-next-states-role-id/fizz.yaml
+fizz.yaml not found. Using default options
+StateSpaceOptions: options:{max_actions:6  max_concurrent_actions:2}  deadlock_detection:false
+Nodes: 3, queued: 0, elapsed: 706.25µs
+Time taken for model checking: 716.5µs
+Writen graph dotfile: examples/references/09-09-next-states-role-id/out/run_2026-07-06_18-21-23/graph.dot
+To generate svg, run: 
+dot -Tsvg examples/references/09-09-next-states-role-id/out/run_2026-07-06_18-21-23/graph.dot -o graph.svg && open graph.svg
+Writen communication diagram dotfile: examples/references/09-09-next-states-role-id/out/run_2026-07-06_18-21-23/communication.dot
+To generate svg, run: 
+dot -Tsvg examples/references/09-09-next-states-role-id/out/run_2026-07-06_18-21-23/communication.dot -o communication.svg && open communication.svg
+Valid Nodes: 3 Unique states: 3
+IsLive: true
+Time taken to check liveness: 225.375µs
+PASSED: Model checker completed successfully
+Writen 1 node files and 1 link files to dir examples/references/09-09-next-states-role-id/out/run_2026-07-06_18-21-23

--- a/examples/references/GOTCHAS.md
+++ b/examples/references/GOTCHAS.md
@@ -334,3 +334,53 @@ spec is genuinely unbounded (find the loop and fix the spec). PASSED at
 
 See `VERIFICATION_GUIDE.md` §8 for the full pattern, more examples, and
 how to identify which variables to bound.
+
+## 14. Role Objects Compare by Pointer — Never Compare Roles Across States
+
+**Symptom**: `before.leader == after.leader` is always False in a transition
+assertion even when it's "the same" role. `n.role_id == w` never matches in
+a `next_states()` filter. `after.workers` membership checks or dict lookups
+keyed by a role from `before` silently fail.
+
+**Cause**: `Role` values compare by pointer identity, and every state
+(`before`, `after`, each `next_states()` successor, each assertion
+evaluation) is a separate clone. Within ONE state, aliasing is preserved, so
+`current_leader == workers[0]` works — but across states, the "same" role is
+a different pointer and every comparison is silently False. (Roles do hash
+by value, which makes dict lookups extra confusing: the bucket is found, the
+key still doesn't match.)
+
+**Fix**: Compare identity VALUES, not role objects:
+
+```python
+# ❌ WRONG: pointer comparison across states — always False
+transition assertion LeaderStable(before, after):
+    return before.leader == after.leader
+
+# ✅ CORRECT: compare __id__ (a value with proper equality)
+transition assertion LeaderStable(before, after):
+    return before.leader.__id__ == after.leader.__id__
+
+# ✅ CORRECT: next_states() role filtering via role_id
+witnesses = [n for n in next_states() if n.role_id == w.__id__]
+```
+
+Store `__id__` values (not role objects) in records and dicts whenever the
+data crosses state boundaries: `record(customer=self.__id__)`.
+
+Id values expose their components: `w.__id__.name` → `"Worker"`,
+`w.__id__.index` → `0`.
+
+## 15. Keywords Cannot Be Attribute Names
+
+**Symptom**: `mismatched input 'action' expecting {..., NAME}` parse error
+on something like `n.action` or `self.role`.
+
+**Cause**: fizz keywords (`action`, `role`, `func`, `oneof`, ...) are
+reserved even in attribute position after a dot.
+
+**Fix**: Pick non-keyword names for record/struct fields (`action_name`,
+`role_ref`). Built-in structs follow the same convention — `next_states()`
+transitions use `action_name` and `role_ref` for exactly this reason.
+Multi-line list comprehensions also fail to parse — keep comprehensions on
+one line.

--- a/examples/references/LANGUAGE_REFERENCE.md
+++ b/examples/references/LANGUAGE_REFERENCE.md
@@ -821,6 +821,67 @@ transition assertion AlwaysIncreases(before, after):
 
 **Pattern**: Always check `before != after` before asserting a property about the change
 
+### next_states() — One-Step Lookahead (ENABLED-style properties)
+
+Inside an `always assertion`, `next_states()` returns the list of successor
+transitions from the state under check — one entry per enabled transition,
+each executed to its first yield point. This expresses TLA+ ENABLED-style
+safety properties with arbitrary quantifier nesting, e.g. "every item in the
+trash must be restorable *right now*":
+
+```python
+always assertion EveryTrashItemRestorable:
+    for k in items:
+        if items[k] == "trash":
+            if len([n for n in next_states() if n.state.items[k] == "active"]) == 0:
+                return False
+    return True
+```
+
+Each transition is a struct:
+
+| Field | Type | Example | Notes |
+|---|---|---|---|
+| `name` | string | `"Customer#0.PlaceOrder"` | Flat label; also `"thread-0"`, `"channel-0-message-1"` |
+| `kind` | string | `"action"` | `"action"`, `"thread"`, or `"channel"` |
+| `role_ref` | string / None | `"Customer#0"` | None for non-role transitions |
+| `role_id` | id value / None | `Customer0` | Same value as the role's `__id__`; compares by value |
+| `action_name` | string / None | `"PlaceOrder"` | Bare action name; None for thread/channel |
+| `state` | struct | `n.state.items` | Successor state vars — same shape as `before`/`after` in transition assertions |
+
+(`action_name`/`role_ref` — not `action`/`role` — because `action` and `role`
+are fizz keywords and cannot appear as attribute names.)
+
+To scope a check to a specific role instance, compare ids — never role
+objects (roles compare by pointer and never match across states; see
+GOTCHAS):
+
+```python
+always assertion EveryIdleWorkerCanWork:
+    for w in workers:
+        if w.status == "idle":
+            if len([n for n in next_states() if n.action_name == "Work" and n.role_id == w.__id__]) == 0:
+                return False
+    return True
+```
+
+Id values also expose their components: `w.__id__.name` → `"Worker"`,
+`w.__id__.index` → `0`.
+
+**Semantics**:
+- Successors **ignore exploration bounds** (`max_actions` depth,
+  `max_concurrent_actions`, per-action caps). Enabledness is a property of
+  the state, not the scheduler — so the check does not false-fail at the
+  depth frontier or when in-flight actions exhaust the concurrency cap.
+- Crash variants are excluded.
+- For **non-atomic (serial) actions**, the successor is the action's *first
+  yield point* — effects later in the body are not yet visible. Use
+  effect predicates (`n.state.x == ...`) with atomic witness actions; use
+  name filtering (`n.action_name == ...`) to check a serial action can start.
+- Computed lazily, once per checked state. Works in model checking (BFS/DFS),
+  simulation, and no-graph modes. Not available in composition specs.
+- Reference examples: `09-06` through `09-09`.
+
 ### Eventually Always (Liveness)
 
 Eventually reaches a stable state:

--- a/lib/starlark_role.go
+++ b/lib/starlark_role.go
@@ -22,6 +22,30 @@ func ClearRoleRefs() {
 	roleRefs = map[string]int64{}
 }
 
+// GlobalRefsSnapshot captures the package-level allocation counters that
+// action execution mutates as a side effect (role refs, channel ids).
+// Speculative execution that will be discarded (e.g. the next_states()
+// assertion probe) must snapshot before executing and restore after, so the
+// discarded runs don't shift the ref numbering of subsequent real
+// exploration.
+type GlobalRefsSnapshot struct {
+	roleRefs      map[string]int64
+	nextChannelId int
+}
+
+func SnapshotGlobalRefs() GlobalRefsSnapshot {
+	copied := make(map[string]int64, len(roleRefs))
+	for k, v := range roleRefs {
+		copied[k] = v
+	}
+	return GlobalRefsSnapshot{roleRefs: copied, nextChannelId: nextChannelId}
+}
+
+func RestoreGlobalRefs(s GlobalRefsSnapshot) {
+	roleRefs = s.roleRefs
+	nextChannelId = s.nextChannelId
+}
+
 type Role struct {
 	ID          starlark.Value // Can be *ModelValue or *SymmetricValue
 	Name        string

--- a/lib/starlark_types.go
+++ b/lib/starlark_types.go
@@ -1300,8 +1300,29 @@ func (m *ModelValue) Hash() (uint32, error) {
 	return starlark.String(m.FullString()).Hash()
 }
 
+// Attr exposes the id's components to specs: for a role id or symmetric
+// value like Customer#0 / order2, .name is the role/domain name ("Customer",
+// "order") and .index is the numeric part (0, 2). This is the supported way
+// to get at the components — str(id) concatenates them ("Customer0") and
+// would need brittle parsing. SymmetricValue embeds ModelValue, so these
+// attrs are available on both.
+func (m *ModelValue) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "name":
+		return starlark.String(m.prefix), nil
+	case "index":
+		return starlark.MakeInt64(m.id), nil
+	}
+	return nil, nil
+}
+
+func (m *ModelValue) AttrNames() []string {
+	return []string{"index", "name"}
+}
+
 var _ starlark.Value = (*ModelValue)(nil)
 var _ starlark.Comparable = (*ModelValue)(nil)
+var _ starlark.HasAttrs = (*ModelValue)(nil)
 
 // NewSymmetricValue creates a new symmetric value with the default Nominal kind.
 // This maintains backward compatibility with existing code.

--- a/modelchecker/invariants.go
+++ b/modelchecker/invariants.go
@@ -71,7 +71,17 @@ func CheckTransitionInvariants(process *Process) map[int][]int {
 	}
 	return results
 }
+// NextStatesProber lazily computes the successor yield-states of the process
+// being checked, for the next_states() assertion builtin. nil means the
+// builtin is unavailable in this evaluation context (composition joins,
+// post-run re-evaluation).
+type NextStatesProber func() []*NextTransition
+
 func CheckInvariants(process *Process) map[int][]int {
+	return CheckInvariantsWithProber(process, nil)
+}
+
+func CheckInvariantsWithProber(process *Process, prober NextStatesProber) map[int][]int {
 	if len(process.Files) > 1 {
 		panic("Invariant checking not supported for multiple files")
 	}
@@ -91,7 +101,7 @@ func CheckInvariants(process *Process) map[int][]int {
 				if slices.Contains(invariant.TemporalOperators, "transition") {
 					continue
 				}
-				passed = CheckAssertion(process, invariant, j)
+				passed = CheckAssertion(process, invariant, j, prober)
 				if (slices.Contains(invariant.TemporalOperators, "eventually") || slices.Contains(invariant.TemporalOperators, "exists")) && passed /*&& (len(process.Threads) == 0 || process.Name == "yield")*/ {
 					process.Witness[i][j] = true
 				} else if !(slices.Contains(invariant.TemporalOperators, "eventually") || slices.Contains(invariant.TemporalOperators, "exists")) && !passed {
@@ -124,12 +134,53 @@ func CheckInvariant(process *Process, invariant *ast.Invariant) bool {
 	return bool(cond.Truth())
 }
 
-func CheckAssertion(process *Process, invariant *ast.Invariant, index int) bool {
+func CheckAssertion(process *Process, invariant *ast.Invariant, index int, prober NextStatesProber) bool {
 	if !slices.Contains(invariant.TemporalOperators, "always") && !slices.Contains(invariant.TemporalOperators, "exists") {
 		panic("Invariant checking supported only for always/always-eventually/eventually-always/exists invariants" + strings.Join(invariant.TemporalOperators, ","))
 	}
 	cloned := process.CloneForAssert(nil, 0)
 	cloned.Heap.state["__returns__"] = NewDictFromStringDict(cloned.Returns)
+	if prober != nil {
+		// next_states() gives assertions one-step lookahead: the list of
+		// successor transitions from the state under check, each a struct
+		// with .name (transition label) and .state (successor heap vars).
+		// Successors are computed lazily on first call and ignore
+		// exploration bounds — see probeNextStates for the semantics.
+		cloned.Heap.state["next_states"] = starlark.NewBuiltin("next_states",
+			func(t *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+				if err := starlark.UnpackArgs("next_states", args, kwargs); err != nil {
+					return nil, err
+				}
+				transitions := prober()
+				elems := make([]starlark.Value, 0, len(transitions))
+				for _, tr := range transitions {
+					var role starlark.Value = starlark.None
+					if tr.Role != "" {
+						role = starlark.String(tr.Role)
+					}
+					var roleId starlark.Value = starlark.None
+					if tr.RoleId != nil {
+						roleId = tr.RoleId
+					}
+					var action starlark.Value = starlark.None
+					if tr.Action != "" {
+						action = starlark.String(tr.Action)
+					}
+					// Field names deliberately avoid fizz grammar keywords:
+					// `action` and `role` are reserved words, so `n.action`
+					// would not parse in a spec. Hence action_name / role_ref.
+					elems = append(elems, starlarkstruct.FromStringDict(starlark.String("transition"), starlark.StringDict{
+						"name":        starlark.String(tr.Name),
+						"kind":        starlark.String(tr.Kind),
+						"role_ref":    role,
+						"role_id":     roleId,
+						"action_name": action,
+						"state":       starlarkstruct.FromStringDict(starlark.String("state"), tr.State.Heap.state),
+					}))
+				}
+				return starlark.NewList(elems), nil
+			})
+	}
 
 	return execAssertionFunction(cloned, index, invariant)
 }

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -1441,7 +1441,7 @@ func (p *Processor) InitializeNode() (*Node, *Node, error) {
 		}
 		process.Enable()
 		process.Heap.state = globals
-		failed := CheckInvariants(process)
+		failed := CheckInvariantsWithProber(process, p.makeProber(process))
 		if len(failed[0]) > 0 {
 			p.Init.Process.FailedInvariants = failed
 			if !p.config.ContinuePathOnInvariantFailures {
@@ -1810,6 +1810,223 @@ func (p *Processor) printPeakSummary() {
 		p.peakQueueLen, p.peakPendingActionStarts)
 }
 
+// makeProber wraps probeNextStates in a lazily-evaluated, memoized closure.
+// The probe runs only if some assertion actually calls next_states(), and at
+// most once per checked state even when multiple assertions call it.
+func (p *Processor) makeProber(process *Process) NextStatesProber {
+	var cache []*NextTransition
+	done := false
+	return func() []*NextTransition {
+		if !done {
+			cache = p.probeNextStates(process)
+			done = true
+		}
+		return cache
+	}
+}
+
+// NextTransition is one successor yield-state discovered by probeNextStates,
+// exposed to assertions via the next_states() builtin.
+type NextTransition struct {
+	// Name is the flat transition label: the action name ("Reset"), the
+	// role-qualified action name ("Customer#0.PlaceOrder"), a thread
+	// continuation ("thread-0"), or a channel delivery
+	// ("channel-0-message-1").
+	Name string
+	// Kind is "action", "thread", or "channel".
+	Kind string
+	// Role is the role instance label ("Customer#0") for role actions,
+	// "" otherwise.
+	Role string
+	// RoleId is the role's identity value (what specs see as __id__) for
+	// role actions, nil otherwise. Unlike Role objects — which compare by
+	// pointer and therefore never match across clones — this compares by
+	// value, so assertions can write `n.role_id == c.__id__`.
+	RoleId starlark.Value
+	// Action is the bare action name ("PlaceOrder") for kind "action",
+	// "" otherwise.
+	Action string
+	// State is the successor process at its first yield point. It is a
+	// throwaway clone: safe for assertions to inspect, never attached to
+	// the graph or the exploration queue.
+	State *Process
+}
+
+// probeNextStates computes every yield-successor of the given process for
+// the next_states() assertion builtin. It deliberately IGNORES exploration
+// bounds — MaxActions depth, MaxConcurrentActions, and per-action caps —
+// because enabledness is a property of the state, not of the exploration
+// schedule (TLA+ ENABLED semantics). Without this, assertions like "every
+// trash item is restorable" would false-fail at the depth frontier and at
+// states where in-flight non-atomic actions exhaust the concurrency cap.
+//
+// Everything created here is discarded: probe forks are never attached,
+// never enter p.queue/p.visited, and are not invariant-checked (which also
+// prevents recursion — a probed state must not re-probe). lib-level
+// allocation counters (role refs, channel ids) are snapshotted and restored
+// so the discarded execution doesn't shift ref numbering for subsequent
+// real exploration.
+//
+// Crash variants are intentionally excluded: a crash is not a witness that
+// an action is possible.
+func (p *Processor) probeNextStates(process *Process) []*NextTransition {
+	snapshot := lib.SnapshotGlobalRefs()
+	defer lib.RestoreGlobalRefs(snapshot)
+
+	// Temp wrapper node; ForkForAction/ForkForAlternatePaths only read it.
+	base := &Node{Process: process}
+
+	type probeStart struct {
+		node   *Node
+		name   string
+		kind   string
+		role   string
+		roleId starlark.Value
+		action string
+	}
+	starts := make([]*probeStart, 0)
+
+	// 1. Continuations of in-flight threads (non-atomic actions mid-way).
+	for i, thread := range process.Threads {
+		if thread == nil || thread.currentPc() == "" {
+			continue
+		}
+		name := fmt.Sprintf("thread-%d", i)
+		nn := base.ForkForAlternatePaths(thread.Process.Fork(), name)
+		nn.Current = i
+		nn.ThreadProgress = true
+		starts = append(starts, &probeStart{node: nn, name: name, kind: "thread"})
+	}
+
+	// 2. Pending channel message deliveries (mirrors scheduleChannelMessages).
+	for i, msgs := range process.ChannelMessages {
+		for j := range msgs {
+			linkName := fmt.Sprintf("channel-%d-message-%d", i, j)
+			nn := base.ForkForAlternatePaths(process.Fork(), linkName)
+			newMsg := nn.ChannelMessages[i][j]
+			nn.ChannelMessages[i] = append(nn.ChannelMessages[i][:j], nn.ChannelMessages[i][j+1:]...)
+			thread := nn.Process.NewThread()
+			thread.Stack.Pop()
+			thread.Stack.Push(newMsg.Frame())
+			starts = append(starts, &probeStart{node: nn, name: linkName, kind: "channel"})
+		}
+	}
+
+	// 3. Fresh global actions (mirrors scheduleAction, minus the cap checks).
+	for i, action := range p.Files[0].Actions {
+		if action.Name == "Init" {
+			continue
+		}
+		nn := base.ForkForAction(nil, nil, action)
+		thread := nn.Process.NewThread()
+		frame := thread.currentFrame()
+		frame.pc = fmt.Sprintf("Actions[%d]", i)
+		frame.Name = action.Name
+		starts = append(starts, &probeStart{node: nn, name: action.Name, kind: "action", action: action.Name})
+	}
+
+	// 4. Fresh role actions for every live role instance.
+	if len(process.Roles) > 0 {
+		roleMap := make(map[string]int)
+		for i, role := range p.Files[0].Roles {
+			roleMap[role.Name] = i
+		}
+		for _, role := range process.Roles {
+			if role == nil {
+				continue
+			}
+			roleIndex, ok := roleMap[role.Name]
+			if !ok {
+				continue
+			}
+			roleAst := p.Files[0].Roles[roleIndex]
+			for i, action := range roleAst.Actions {
+				if action.Name == "Init" {
+					continue
+				}
+				nn := base.ForkForAction(nil, role, action)
+				thread := nn.Process.NewThread()
+				frame := thread.currentFrame()
+				for _, r := range nn.Roles {
+					if r != nil && r.RefStringShort() == role.RefStringShort() {
+						frame.obj = r
+						break
+					}
+				}
+				if frame.obj == nil {
+					// Role no longer reachable in this state (mirrors the
+					// same filter in scheduleAction).
+					continue
+				}
+				frame.pc = fmt.Sprintf("Roles[%d].Actions[%d]", roleIndex, i)
+				frame.Name = role.Name + "." + action.Name
+				starts = append(starts, &probeStart{
+					node:   nn,
+					name:   role.RefStringShort() + "." + action.Name,
+					kind:   "action",
+					role:   role.RefStringShort(),
+					roleId: role.GetId(),
+					action: action.Name,
+				})
+			}
+		}
+	}
+
+	// Execute each start to its first yield, following every intermediate
+	// fork (oneof/for splits). Local dedup only — nothing touches p.visited.
+	// Ordering matters: dedup AFTER Execute (mirroring processNode). Choice
+	// forks share the parent's state until they execute their choice binding,
+	// so deduping at push time would collapse sibling oneof branches.
+	results := make([]*NextTransition, 0)
+	seenYield := make(map[string]bool)
+	for _, start := range starts {
+		seenIntermediate := make(map[string]bool)
+		stack := []*Node{start.node}
+		for len(stack) > 0 {
+			n := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+
+			n.CachedHashCode = ""
+			forks, yield := n.currentThread().Execute()
+			if len(forks) == 0 && !n.Enabled && !n.ThreadProgress {
+				// Disabled path: a require failed or the body was a no-op.
+				continue
+			}
+			if n.ThreadProgress {
+				n.Enable()
+			}
+			h := n.HashCode()
+			if seenIntermediate[h] {
+				continue
+			}
+			seenIntermediate[h] = true
+			if !yield {
+				for _, fork := range forks {
+					stack = append(stack, n.ForkForAlternatePaths(fork, fork.Name))
+				}
+				continue
+			}
+			// Key on (transition name, state hash): two different actions
+			// reaching the same state are distinct transitions, and name
+			// filtering in assertions must see both.
+			key := start.name + "|" + h
+			if seenYield[key] {
+				continue
+			}
+			seenYield[key] = true
+			results = append(results, &NextTransition{
+				Name:   start.name,
+				Kind:   start.kind,
+				Role:   start.role,
+				RoleId: start.roleId,
+				Action: start.action,
+				State:  n.Process,
+			})
+		}
+	}
+	return results
+}
+
 func (p *Processor) StartSimulation() (init *Node, failedNode *Node, err error) {
 	if p.Init != nil {
 		panic("processor already started")
@@ -2174,7 +2391,7 @@ func (p *Processor) processNode(node *Node) (bool, bool) {
 	}
 	var failedInvariants map[int][]int
 	if yield {
-		failedInvariants = CheckInvariants(node.Process)
+		failedInvariants = CheckInvariantsWithProber(node.Process, p.makeProber(node.Process))
 	}
 	if len(failedInvariants[0]) > 0 {
 		//panic(fmt.Sprintf("Invariant failed: %v", failedInvariants))
@@ -2310,7 +2527,7 @@ func (p *Processor) crashRole(node *Node, role *lib.Role) (*Node, *Node) {
 	p.ResetEphemeralVariables(crashNode, role)
 	crashNode.Enable()
 
-	failedInvariants := CheckInvariants(crashFork)
+	failedInvariants := CheckInvariantsWithProber(crashFork, p.makeProber(crashFork))
 	if len(failedInvariants[0]) > 0 {
 		crashNode.Process.FailedInvariants = failedInvariants
 		if !p.config.ContinuePathOnInvariantFailures {
@@ -2345,7 +2562,7 @@ func (p *Processor) crashThread(node *Node) {
 	}
 	// TODO: We could just copy the failed invariants from the parent
 	// instead of checking again
-	CheckInvariants(crashFork)
+	CheckInvariantsWithProber(crashFork, p.makeProber(crashFork))
 	if node.Process.Enabled {
 		crashNode.Enable()
 	}


### PR DESCRIPTION
…ions

Adds one-step lookahead to always assertions: next_states() returns the list of successor transitions from the state under check. Each entry is a struct:

    transition(name, kind, role_ref, role_id, action_name, state)

- name: flat label ("Customer#0.PlaceOrder", "thread-0", "channel-0-message-1")
- kind: "action" | "thread" | "channel"
- role_ref: role instance label ("Customer#0"), None for non-role transitions
- role_id: the role's identity value (same as __id__) — compares by VALUE, so n.role_id == w.__id__ scopes a check to a role instance. Role objects themselves compare by pointer and never match across clones, so the Role object is deliberately not exposed.
- action_name: bare action name. Named action_name/role_ref (not action/role) because those are fizz keywords and cannot appear in attribute position.
- state: successor heap vars at the first yield point — same struct shape as before/after in transition assertions.

This expresses TLA+ ENABLED-style safety properties with arbitrary quantifier nesting — e.g. "every item in the trash is restorable":

    always assertion EveryTrashItemRestorable:
        for k in items:
            if items[k] == "trash":
                if len([n for n in next_states() if n.state.items[k] == "active"]) == 0:
                    return False
        return True

The forall-item-exists-successor shape is not expressible with transition assertions, and a global-reachability `exists` formulation cannot catch ordering-restricted designs (stack-like trash where only the most recent deletion is restorable) — pinned by the 09-07 example.

Semantics:

- The probe (probeNextStates) IGNORES exploration bounds — max_actions depth, max_concurrent_actions, per-action caps. Enabledness is a property of the state, not the exploration schedule; without this, assertions would false-fail at the depth frontier and at states where in-flight non-atomic actions exhaust the concurrency cap (pinned by 09-08).
- Probe forks are throwaway: never attached, queued, or invariant-checked (no recursion). lib-level allocation counters (role refs, channel ids) are snapshotted/restored so discarded probe execution cannot shift ref numbering of real exploration.
- Crash variants are excluded from the successor set.
- Non-atomic actions: successor is the FIRST yield point; use name filtering for "can this serial action start".
- Intermediate-fork dedup happens AFTER Execute (mirrors processNode): sibling oneof forks share the parent's state until the choice binding runs; deduping at push time would collapse them (pinned by 09-06).
- Lazy + memoized; zero cost for specs that don't call it. Verified BFS, DFS, --experimental_processed_queue, --experimental_no_graph, and simulation. Unavailable in composition joins.

Also exposes id components to specs via new attrs on ModelValue (inherited by SymmetricValue): id.name -> "Worker", id.index -> 0. Previously the only option was parsing str(id) ("Worker0").

Docs: LANGUAGE_REFERENCE next_states() section; GOTCHAS #14 (role objects compare by pointer across states — compare __id__ values; also applies to transition assertions' before/after) and #15 (keywords cannot be attribute names; multi-line comprehensions do not parse).

Reference examples: 09-06 (unrestricted restore, PASSES), 09-07 (stack trash, FAILS with assertion name), 09-08 (concurrency-cap false positive guard), 09-09 (role_id discrimination + id attrs).