### PR TITLE
fix(mbt): emit #[async_trait] on generated Rust model trait and adapt…

### DIFF
--- a/mbt/generator/templates/rust/adapters.rs.j2
+++ b/mbt/generator/templates/rust/adapters.rs.j2
@@ -48,6 +48,7 @@ pub struct {{ model_name }}ModelAdapter {
 }
 
 // Assert that {{ model_name }}ModelAdapter satisfies {{ model_name }}Model
+#[async_trait]
 impl {{ model_name }}Model for {{ model_name }}ModelAdapter {
     {% for role in file.roles -%}
     type R{{ loop.index0 }} = {{ role.name }}RoleAdapter;

--- a/mbt/generator/templates/rust/traits.rs.j2
+++ b/mbt/generator/templates/rust/traits.rs.j2
@@ -20,6 +20,11 @@ pub trait {{ role.name }}Role: AsyncRole {
 {% endfor %}
 
 // Model trait
+// #[async_trait] is required: without it, the async fns desugar to native
+// async-fn-in-trait futures with no Send bound, and the dispatcher in the
+// generated test file (which boxes dyn Future + Send via #[async_trait])
+// cannot await them.
+#[async_trait]
 pub trait {{ model_name }}Model: Model {
     {%- for role in file.roles %}
     // R{{ loop.index0 }} is the trait for the {{ role.name }}Role


### PR DESCRIPTION
…er impl

The Rust scaffold generated role traits with #[async_trait] but left it off the model trait (traits.rs.j2) and the generated `impl <Spec>Model for <Spec>ModelAdapter` block (adapters.rs.j2). For specs with top-level (non-role) actions, the model trait's async fns desugared to native async-fn-in-trait futures with no Send bound, and the generated dispatcher in test.rs — whose #[async_trait] DispatchModel impl boxes dyn Future + Send — failed to compile:

    error: future cannot be sent between threads safely
    ... await occurs here on type `impl Future<Output = Result<Value,
    MbtError>>`, which is not `Send`

Verified by compiling the generated scaffold against mbt/lib/rust with cargo check --all-targets:
- repro spec (role + two top-level actions): compiles with the fix; stripping the two attributes reproduces the exact reported error.
- role-only spec (model trait has no async fns): #[async_trait] is a no-op there and compiles unchanged.

Fixes #364