### PR TITLE
feat(modelchecker): --no-symmetry-reduction flag for MBT-replayable graphs

### DIFF
--- a/fizz
+++ b/fizz
@@ -170,6 +170,12 @@ usage() {
   echo "  $0 mbt-scaffold [options] filename"
   echo "  $0 [-x|--simulation] [--test] [--seed int64Number] [--max_runs intNumber] [--simulation_first_traces intNumber] [--exploration_strategy dfs] [--trace-file tracefile | --trace tracestring] [--preinit-hook-file hookfile | --preinit-hook hookstring] [--copy-ast] [--no-copy-ast] [--output-dir directory] [--parallel intNumber] [experimental] filename"
   echo ""
+  echo "  --no-symmetry-reduction"
+  echo "    Disable symmetry reduction. Every persisted state keeps its"
+  echo "    concrete symmetric values / role identities (no canonical"
+  echo "    renaming). Larger state space. Required when generating state"
+  echo "    graphs for MBT replay from specs using symmetric roles/values."
+  echo ""
   echo "  --parallel N"
   echo "    Run N simulation processes in parallel (only with -x and no --seed)."
   echo "    Workers split --max_runs evenly. Each worker writes to its own"
@@ -211,6 +217,7 @@ preinit_hook_string=""
 experimental_processed_queue=false
 experimental_no_graph=false
 experimental_no_state_returns=false
+no_symmetry_reduction=false
 parallel=1
 
 # Parse options
@@ -338,6 +345,10 @@ while [[ "$1" =~ ^- ]]; do
       experimental_no_state_returns=true
       shift
       ;;
+    --no-symmetry-reduction )
+      no_symmetry_reduction=true
+      shift
+      ;;
     --parallel )
       if [[ -n "$2" ]] && [[ "$2" =~ ^[0-9]+$ ]]; then
         parallel="$2"
@@ -407,6 +418,9 @@ if [ "$experimental_no_graph" = true ]; then
 fi
 if [ "$experimental_no_state_returns" = true ]; then
   args+=("--experimental_no_state_returns")
+fi
+if [ "$no_symmetry_reduction" = true ]; then
+  args+=("--no-symmetry-reduction")
 fi
 if [ "$seed" -ne 0 ]; then
   args+=("--seed" "$seed")

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var isTest bool
 var experimentalProcessedQueue bool
 var experimentalNoGraph bool
 var experimentalNoStateReturns bool
+var noSymmetryReduction bool
 
 func main() {
 	args := parseFlags()
@@ -696,6 +697,7 @@ func modelCheckSingleSpec(f *ast.File, stateConfig *ast.StateSpaceOptions, dirPa
 		p1.SetExperimentalProcessedQueue(experimentalProcessedQueue)
 		p1.SetExperimentalNoGraph(experimentalNoGraph)
 		p1.SetExperimentalNoStateReturns(experimentalNoStateReturns)
+		p1.SetDisableSymmetryReduction(noSymmetryReduction)
 		holder.Store(p1)
 
 		rootNode, failedNode, endTime, err := startModelChecker(p1)
@@ -1082,6 +1084,7 @@ func parseFlags() []string {
 	flag.BoolVar(&experimentalProcessedQueue, "experimental_processed_queue", false, "EXPERIMENTAL: queue holds processed (yield-point) nodes instead of unprocessed action-starts. Dedupes successors before they enter the queue, reducing peak queue memory (~10x on BFS, ~3x on DFS). State space and assertion outcomes are identical under BFS. Under DFS/Random combined with max_actions, the changed exploration order may prune a different subset of states than the default path within the bound — raise max_actions above the spec's natural diameter to avoid the divergence. Default=false.")
 	flag.BoolVar(&experimentalNoGraph, "experimental_no_graph", false, "EXPERIMENTAL: drops the in-memory state graph after processing each yield-point. Keeps symmetry reduction, dedup, unique-state count, and safety/transition assertions. Does NOT support liveness assertions — refuses to run if any are present. Auto-enables --experimental_processed_queue. Massive RSS reduction at the cost of trace replayability (only a lightweight action-name chain is kept for failure reporting). Default=false.")
 	flag.BoolVar(&experimentalNoStateReturns, "experimental_no_state_returns", false, "EXPERIMENTAL: omit Process.Returns from HashCode, JSON state, and dot-file state labels. Returns remain available on Link.Returns (the per-transition field). Use this to verify downstream consumers (graph, MBT, explorer) have migrated to reading return values from links. Planned to become the default. Default=false.")
+	flag.BoolVar(&noSymmetryReduction, "no-symmetry-reduction", false, "Disable symmetry reduction: dedup uses only the plain state hash, so every persisted state keeps its concrete symmetric values/role identities (no canonical renaming). Larger state space. Required when generating state graphs for MBT replay from specs that use symmetric roles or symmetry values. Default=false.")
 	flag.Parse()
 
 	// Validate that both file and string versions are not provided

--- a/modelchecker/processor.go
+++ b/modelchecker/processor.go
@@ -1178,6 +1178,12 @@ type Processor struct {
 	// remains intact so a failure trace can be reconstructed on demand.
 	experimentalNoGraph bool
 
+	// disableSymmetryReduction: when true, visited-set dedup uses only the
+	// plain state hash — no symmetry permutations, so no canonical renaming
+	// of symmetric values/roles in stored states. Larger state space, but
+	// every persisted state stays concrete, which MBT graph replay requires.
+	disableSymmetryReduction bool
+
 	// pendingActionStarts: NEW-mode buffer used by enqueueScheduled to
 	// collect action-starts that would have gone to p.queue in OLD mode.
 	// Drained by startProcessedQueue while expanding a popped yield-point.
@@ -1239,6 +1245,14 @@ func (p *Processor) SetExperimentalProcessedQueue(v bool) {
 // experimentalProcessedQueue and for refusing specs with liveness assertions.
 func (p *Processor) SetExperimentalNoGraph(v bool) {
 	p.experimentalNoGraph = v
+}
+
+// SetDisableSymmetryReduction turns off symmetry-permutation dedup so every
+// persisted state stays concrete. Must be called before Start. Intended for
+// generating MBT-replayable graphs from specs that use symmetric roles or
+// symmetry.nominal values.
+func (p *Processor) SetDisableSymmetryReduction(v bool) {
+	p.disableSymmetryReduction = v
 }
 
 // SetExperimentalNoStateReturns toggles whether Process.Returns is included
@@ -2611,8 +2625,14 @@ func (p *Process) minHashCode(hashes []string) string {
 // findVisitedSymmetric looks up a node in the visited map by trying all symmetry
 // permutation hashes. Returns the matching node and true if found, nil and false otherwise.
 func (p *Processor) findVisitedSymmetric(node *Node) (*Node, bool, string) {
-	// Skip symmetry reduction in simulation mode - we only check one path anyway
-	if p.simulation {
+	// Skip symmetry reduction in simulation mode (we only check one path
+	// anyway) or when explicitly disabled. Disabling keeps every persisted
+	// state concrete — no canonical renaming of symmetric values/roles —
+	// which is required for consumers that replay the graph against a real
+	// system (MBT): links reference concrete identities, and a canonically
+	// renamed destination state would not match them. Exact-duplicate
+	// states still dedup via the plain hash.
+	if p.simulation || p.disableSymmetryReduction {
 		hash := node.HashCode()
 		other, ok := p.visited[hash]
 		return other, ok, hash


### PR DESCRIPTION
## Summary

Symmetry reduction stores only the canonical representative of each equivalence class, and links carry no permutation witness. Consumers that replay the persisted graph against a real system — the MBT runner — therefore break on specs with symmetric roles/values:

- a trace executes `Worker#1.put` but the canonicalized destination node only contains `Worker#0`, so link lookup fails ("No matching Source Link found")
- role lookup by original id returns nil
- `Any:` args reference renamed identities

This adds `--no-symmetry-reduction`: dedup uses only the plain state hash (the same branch simulation mode has used since #316), so every persisted state stays concrete and link names / role refs / choice args always match destination states. Exact-duplicate states still dedup.

This is **phase 1** of symmetric-spec MBT support. Phase 2 (recording the permutation witness on links + composing renames in the MBT runner) would restore full reduction for MBT graphs later.

## Trade-off

State space grows by up to the permutation factor per symmetric domain (16-02-symmetric-roles: 10 → 27 states). Acceptable at MBT-scale configs; opt-in only.

## Verification

- Flag off: full reference suite unchanged (98/98) — the condition degenerates to the existing `if p.simulation`.
- Flag on: 16-02 passes with identical verdict; persisted graph shows concrete identities end-to-end (`Worker#1.StartWork` → state where `Worker#1` is WORKING, `completed=["Worker0","Worker1"]`).
- fizz wrapper syntax-checked on macOS bash 3.2 and exercised in both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)