### PR TITLE
feat(docker): slim multi-stage image, variant A: base-image python

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,113 @@
+name: Docker
+
+# Tag policy: `latest` moves on every publish — version tags, the monthly
+# scheduled rebuild, and manual dispatch. A scheduled rebuild republishes
+# the SAME fizzbee code on a refreshed base image (that's the point: base
+# CVE patches reach `latest` without a fizzbee release). Use the semver
+# tags to pin fizzbee versions.
+on:
+  push:
+    tags:
+      - "v*"
+  schedule:
+    - cron: "17 8 3 * *"
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for the arm64 smoke test)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: fizzbee:smoke-amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # The builder cross-compiles arm64 on the amd64 runner (no emulation:
+      # the runtime stage has no RUN steps). Only the smoke test below runs
+      # the arm64 binaries, under QEMU.
+      - name: Build arm64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: fizzbee:smoke-arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # NOTE: exit status alone is NOT a sufficient assertion — the fizzbee
+      # binary exits 0 even when the model checker reports FAILED, so the
+      # PASSED grep is the real check. Two specs: Counter is the minimal
+      # sanity check; two-phase-commit exercises roles, functions, and much
+      # more of the parser's python dependency surface (antlr4, protobuf).
+      - name: Smoke test (amd64)
+        run: |
+          set -euo pipefail
+          for spec_dir in examples/references/01-02-atomic-action:Counter.fizz \
+                          examples/references/13-02-01-two-phase-commit:TwoPhaseCommit.fizz; do
+            dir="${spec_dir%%:*}"; spec="${spec_dir##*:}"
+            docker run --rm -v "$PWD/$dir":/workspace fizzbee:smoke-amd64 "$spec" | tee /tmp/smoke.out
+            grep -q "PASSED: Model checker completed successfully" /tmp/smoke.out
+          done
+          docker run --rm --entrypoint /opt/fizzbee/fizz fizzbee:smoke-amd64 mbt-scaffold --help > /dev/null
+
+      - name: Smoke test (arm64, via QEMU)
+        run: |
+          set -euo pipefail
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/examples/references/01-02-atomic-action":/workspace \
+            fizzbee:smoke-arm64 Counter.fizz | tee /tmp/smoke-arm64.out
+          grep -q "PASSED: Model checker completed successfully" /tmp/smoke-arm64.out
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify published manifest lists both architectures
+        run: |
+          set -euo pipefail
+          ref="$(echo '${{ steps.meta.outputs.tags }}' | head -1)"
+          docker buildx imagetools inspect "$ref" | tee /tmp/manifest.out
+          grep -q "linux/amd64" /tmp/manifest.out
+          grep -q "linux/arm64" /tmp/manifest.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,82 @@
-FROM gcr.io/bazel-public/bazel:latest
+# Multi-stage build: a heavyweight bazel builder stage that cross-compiles
+# for the target architecture, and a slim runtime stage containing only the
+# release artifacts. The runtime stage has NO RUN steps, so multi-arch
+# builds (buildx --platform linux/amd64,linux/arm64) never execute
+# target-arch code — the amd64 builder cross-compiles both.
+#
+# Build:  docker build -t fizzbee .
+# Run:    docker run --rm -v "$PWD":/workspace fizzbee path/to/Spec.fizz
+#
+# This image intentionally DIVERGES from the release-tarball layout
+# (release/build_release.sh) in one way: the parser's bundled hermetic
+# rules_python interpreter is replaced with the runtime base image's
+# python (see the assembly step below). Tarballs keep the hermetic
+# interpreter; the image trades it for one that receives security patches
+# with every base-image rebuild. If you change build_release.sh, check
+# this file too.
+
+# ---- Builder --------------------------------------------------------------
+# Pinned to amd64: gcr.io/bazel-public/bazel publishes no arm64 manifest.
+# Version-pinned for reproducible image builds; bump deliberately alongside
+# .bazelversion changes.
+FROM --platform=linux/amd64 gcr.io/bazel-public/bazel:8.3.1 AS builder
+
+ARG TARGETARCH
 
 WORKDIR /app
-
 COPY . .
 
-RUN bazel build parser/parser_bin
-RUN bazel build --platforms=//:linux_x86 //:fizzbee
+RUN case "$TARGETARCH" in \
+      arm64) PLATFORM=linux_arm ;; \
+      *)     PLATFORM=linux_x86 ;; \
+    esac \
+ && bazel build --platforms=//:"$PLATFORM" //parser/... //:fizzbee //mbt/generator:generator_bin_zip
 
-ENTRYPOINT ["/app/fizz"]
+# Assemble the runtime layout. Starts from the release-tarball layout
+# (fizz, fizz.env, fizzbee, parser/, mbt_gen.zip), then applies the one
+# image-specific change:
+#
+# The parser's runfiles bundle a hermetic rules_python interpreter — a
+# 93MB unstripped binary that cp -L materializes THREE times (python,
+# python3, python3.12 are symlinks upstream), plus an 89MB libpython:
+# ~390MB total, and a frozen interpreter that scanners flag forever.
+# Replace the whole toolchain dir with a symlink to the runtime base
+# image's interpreter (/usr/local/bin/python3): security patches then
+# arrive via `docker pull` after base rebuilds instead of via bazel pin
+# bumps. Same minor version (3.12) as the hermetic toolchain.
+#
+# The stale-venv rm -rf is defensive: rules_python >= 1.9 emits a
+# _parser_bin.venv dir that is broken for cross-compiled binaries (its
+# interpreter symlink references the host-config toolchain). On the
+# current pin (1.0.0) it does not exist; if a future bump reintroduces
+# it, it must not ship.
+RUN mkdir -p /out \
+ && cp -L -R bazel-bin/parser /out/parser \
+ && rm -rf /out/parser/_parser_bin.venv \
+ && cp -L bazel-bin/fizzbee_/fizzbee /out/fizzbee \
+ && cp -L bazel-bin/mbt/generator/generator_bin.zip /out/mbt_gen.zip \
+ && cp fizz /out/fizz \
+ && cp release/fizz.env /out/fizz.env \
+ && chmod -R u+w /out/parser \
+ && chmod +x /out/fizz /out/fizzbee /out/parser/parser_bin \
+ && PYDIR=$(echo /out/parser/parser_bin.runfiles/rules_python++python+python_3_12_*-unknown-linux-gnu) \
+ && rm -rf "$PYDIR" \
+ && mkdir -p "$PYDIR/bin" \
+ && ln -s /usr/local/bin/python3 "$PYDIR/bin/python3"
+
+# ---- Runtime ---------------------------------------------------------------
+# Minor-version pinned: the parser's runfiles point at this image's python,
+# so the base must stay on 3.12 (patch releases are exactly the CVE fixes
+# we want flowing in; a silent jump to 3.13 could change stdlib behavior).
+FROM python:3.12-slim-bookworm
+
+COPY --from=builder /out /opt/fizzbee
+
+# The fizz wrapper sources fizz.env from its own directory, which points
+# PARSER_BIN / FIZZBEE_BIN / MBT_GEN_ZIP at /opt/fizzbee/*.
+ENV PATH="/opt/fizzbee:${PATH}"
+
+# Specs are expected to be mounted here: -v "$PWD":/workspace
+WORKDIR /workspace
+
+ENTRYPOINT ["/opt/fizzbee/fizz"]


### PR DESCRIPTION
## Summary

**Variant A of two** — see PR for `user/jp/feat-docker-hermetic-python` (variant B) for the alternative; the two are mutually exclusive, pick one. Both replace the abandoned single-stage image (full bazel/Ubuntu/JDK build env, gigabytes of unpatched CVE surface).

| | A (this PR) | B (hermetic) |
|---|---|---|
| Parser's python | Base image's (`python:3.12-slim`) via symlink | rules_python bundled interpreter, as tarballs ship |
| Size | **308MB** | 525MB |
| Interpreter CVE patching | `docker pull` after base rebuild | Only via bazel toolchain pin bump + republish |
| Risk | Relies on rules_python runfiles layout (unstable interface); mitigated by pre-push smoke tests on both arches | None beyond status quo |

## Review-feedback changes since the first revision

- **`\|\| true` removed entirely** — the rules_python 1.9.2 bump is dropped (see below), so no venv exists; a defensive documented `rm -rf` guards future bumps.
- **rules_python bump withdrawn**: 1.9.2's venv-based bootstrap is **broken for cross-compiled binaries** (stub disables the venv, no baked imports → `ModuleNotFoundError` at runtime). It would have broken release tarballs for every cross-built platform. Needs separate investigation.
- **`mbt_gen.zip` included** — `fizz mbt-scaffold` works in the container (smoke-tested).
- **Builder pinned** to `gcr.io/bazel-public/bazel:8.3.1`.
- **Smoke tests expanded**: amd64 runs Counter + two-phase-commit (exercises antlr4/protobuf parser surface) + mbt-scaffold; **arm64 runs Counter under QEMU** before any push. PASSED-grep is the real assertion (binary exits 0 even on FAILED — exit code alone is insufficient by design).
- **Post-push manifest verification** (both architectures present).
- **`latest` tag policy documented** in the workflow header (moves on version tags AND monthly rebuilds).
- **Packaging divergence from build_release.sh documented** in the Dockerfile header.

## Verification

- Local (arm64): image assembled via the exact Dockerfile commands runs two-phase-commit with baseline-identical output (331/281) on the base image's interpreter; scaffold works; relative spec paths work.
- `docker scout`: only 4 perl CVEs remain — currently unfixed upstream in every Debian release, present in the bare `python:slim` base too; they clear via the monthly rebuild once Debian ships fixes.
- Builder stage in-container: covered by the workflow's pre-push smoke tests (needs amd64; first `workflow_dispatch` after merge exercises it).

## Post-merge checklist

1. Actions → Docker → Run workflow (no tag needed).
2. Verify smoke tests green; manifest shows both platforms.
3. **Make the ghcr package public** (first publish defaults to private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)