### PR TITLE
feat(docker): thin image wrapping the official release tarball

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,130 @@
+name: Docker
+
+# Publishes ghcr.io/<repo> as a thin wrapper around the official release
+# tarballs. Triggers:
+# - release published: builds the image for that release version. (Not on
+#   tag push — the Release workflow is still uploading assets at that
+#   point; the `published` event fires after assets exist.)
+# - monthly cron: re-downloads the LATEST release onto a freshly pulled
+#   base image, so OS-layer CVE patches reach `latest` without a fizzbee
+#   release.
+# - manual dispatch: optional explicit version.
+#
+# Tag policy: `latest` moves on every publish (releases AND monthly
+# rebuilds — a rebuild republishes the same fizzbee code on a refreshed
+# base). Use the semver tags to pin fizzbee versions.
+on:
+  release:
+    types: [published]
+  schedule:
+    - cron: "17 8 3 * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to package (e.g. v0.5.3); defaults to latest release"
+        required: false
+        default: ""
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve fizzbee version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          elif [ -n "${{ github.event.inputs.version || '' }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)"
+          fi
+          echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
+          # strip leading v for the semver image tags
+          echo "semver=${VERSION#v}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU (for the arm64 smoke test)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: fizzbee:smoke-amd64
+          build-args: |
+            FIZZBEE_VERSION=${{ steps.version.outputs.version }}
+
+      - name: Build arm64 image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: fizzbee:smoke-arm64
+          build-args: |
+            FIZZBEE_VERSION=${{ steps.version.outputs.version }}
+
+      # NOTE: exit status alone is NOT a sufficient assertion — the fizzbee
+      # binary exits 0 even when the model checker reports FAILED, so the
+      # PASSED grep is the real check. Two specs: Counter is the minimal
+      # sanity check; two-phase-commit exercises roles, functions, and much
+      # more of the parser's python dependency surface (antlr4, protobuf).
+      - name: Smoke test (amd64)
+        run: |
+          set -euo pipefail
+          for spec_dir in examples/references/01-02-atomic-action:Counter.fizz \
+                          examples/references/13-02-01-two-phase-commit:TwoPhaseCommit.fizz; do
+            dir="${spec_dir%%:*}"; spec="${spec_dir##*:}"
+            docker run --rm -v "$PWD/$dir":/workspace fizzbee:smoke-amd64 "$spec" | tee /tmp/smoke.out
+            grep -q "PASSED: Model checker completed successfully" /tmp/smoke.out
+          done
+          docker run --rm --entrypoint /opt/fizzbee/fizz fizzbee:smoke-amd64 mbt-scaffold --help > /dev/null
+
+      - name: Smoke test (arm64, via QEMU)
+        run: |
+          set -euo pipefail
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/examples/references/01-02-atomic-action":/workspace \
+            fizzbee:smoke-arm64 Counter.fizz | tee /tmp/smoke-arm64.out
+          grep -q "PASSED: Model checker completed successfully" /tmp/smoke-arm64.out
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            FIZZBEE_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.semver }}
+            ghcr.io/${{ github.repository }}:latest
+
+      - name: Verify published manifest lists both architectures
+        run: |
+          set -euo pipefail
+          ref="ghcr.io/${{ github.repository }}:${{ steps.version.outputs.semver }}"
+          docker buildx imagetools inspect "$ref" | tee /tmp/manifest.out
+          grep -q "linux/amd64" /tmp/manifest.out
+          grep -q "linux/arm64" /tmp/manifest.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,66 @@
-FROM gcr.io/bazel-public/bazel:latest
+# Thin distribution wrapper around the official release tarball.
+#
+# The image installs the SAME artifact that brew/tarball users run — the
+# self-contained platform release built by release/build_release.sh (fizz
+# wrapper, fizzbee binary, parser with its bundled hermetic python
+# toolchain, mbt_gen.zip). No bazel, no source build, no repackaging:
+# one packaging pipeline, many distribution formats.
+#
+# Build:  docker build --build-arg FIZZBEE_VERSION=v0.5.3 -t fizzbee .
+# Run:    docker run --rm -v "$PWD":/workspace fizzbee path/to/Spec.fizz
+#
+# FIZZBEE_VERSION is REQUIRED (no default): a baked-in default would go
+# stale — months later `docker build .` would silently package an old
+# release. Note the image always wraps a PUBLISHED release, never the
+# source checkout it is built from.
+#
+# The fetch stage runs on the BUILD platform (no emulation) and merely
+# downloads + extracts the TARGET platform's tarball; the runtime stage
+# has no RUN steps. So multi-arch builds (buildx --platform
+# linux/amd64,linux/arm64) never execute target-arch code and need no
+# QEMU. Note python:slim (not debian:slim): the fizz wrapper needs bash,
+# and the mbt-scaffold subcommand launches mbt_gen.zip with the system
+# `python`; the parser itself uses the tarball's bundled interpreter.
 
-WORKDIR /app
+# ---- Fetch ----------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM python:3.12-slim-bookworm AS fetch
 
-COPY . .
+ARG FIZZBEE_VERSION
+ARG TARGETARCH
 
-RUN bazel build parser/parser_bin
-RUN bazel build --platforms=//:linux_x86 //:fizzbee
+# Download with the stage's own python (slim ships no curl/wget) and
+# extract. --strip-components drops the fizzbee-<version>-<platform>/
+# top-level directory from the tarball.
+RUN set -e; \
+    if [ -z "$FIZZBEE_VERSION" ]; then \
+      echo "ERROR: FIZZBEE_VERSION is required, e.g. --build-arg FIZZBEE_VERSION=v0.5.3" >&2; \
+      echo "       (available versions: https://github.com/fizzbee-io/fizzbee/releases)" >&2; \
+      exit 1; \
+    fi; \
+    case "$TARGETARCH" in \
+      arm64) PLAT=linux_arm ;; \
+      *)     PLAT=linux_x86 ;; \
+    esac; \
+    URL="https://github.com/fizzbee-io/fizzbee/releases/download/${FIZZBEE_VERSION}/fizzbee-${FIZZBEE_VERSION}-${PLAT}.tar.gz"; \
+    echo "Fetching $URL"; \
+    python3 -c "import urllib.request,sys; urllib.request.urlretrieve(sys.argv[1], '/tmp/fizzbee.tar.gz')" "$URL"; \
+    mkdir -p /opt/fizzbee; \
+    tar -xzf /tmp/fizzbee.tar.gz -C /opt/fizzbee --strip-components=1; \
+    rm /tmp/fizzbee.tar.gz; \
+    test -x /opt/fizzbee/fizz; \
+    test -x /opt/fizzbee/fizzbee; \
+    test -x /opt/fizzbee/parser/parser_bin
 
-ENTRYPOINT ["/app/fizz"]
+# ---- Runtime ---------------------------------------------------------------
+FROM python:3.12-slim-bookworm
+
+COPY --from=fetch /opt/fizzbee /opt/fizzbee
+
+# The fizz wrapper sources fizz.env from its own directory, which points
+# PARSER_BIN / FIZZBEE_BIN / MBT_GEN_ZIP at /opt/fizzbee/*.
+ENV PATH="/opt/fizzbee:${PATH}"
+
+# Specs are expected to be mounted here: -v "$PWD":/workspace
+WORKDIR /workspace
+
+ENTRYPOINT ["/opt/fizzbee/fizz"]


### PR DESCRIPTION
## Summary

**Final architecture after review convergence** (supersedes both earlier variants; #369 can be closed): the Docker image is a thin distribution wrapper around the **official release tarball** — it installs the exact artifact that brew/tarball users run. One packaging pipeline, many distribution formats.

- Fetch stage downloads the platform's release tarball (`FIZZBEE_VERSION` build arg), extracts, sanity-checks the executables. Runtime stage is `python:3.12-slim` + that artifact. **No bazel, no source build, no repackaging, no runfiles assumptions.**
- Fetch runs on the build platform; runtime has no RUN steps → multi-arch without QEMU.
- `python:slim` (not `debian:slim`): the `fizz` wrapper needs bash, `mbt-scaffold` launches `mbt_gen.zip` with system python; the parser uses the tarball's bundled hermetic interpreter unchanged.

## Workflow

- Triggers on `release: published` (fires *after* assets exist — tag-push would race the still-uploading Release workflow), monthly cron (fresh base image → OS CVE patches reach `latest` without a fizzbee release), and manual dispatch with optional version input.
- Pre-push smoke on **both** architectures (amd64: Counter + two-phase-commit + mbt-scaffold; arm64: Counter under QEMU). PASSED-grep is the real assertion (binary exits 0 even on FAILED). Post-push manifest check.

## Verification (against the real v0.5.3 release)

- Image builds from the published tarball; two-phase-commit passes with baseline-identical output (331/281); mbt-scaffold works.
- #371's pip strip confirmed end-to-end: zero pip/ensurepip in the image.
- Size: 704MB — the tarball ships `cp -L`-materialized duplicate interpreter copies. Follow-up: dedupe those in `build_release.sh`, shrinking both the tarballs and this image (~-180MB); deliberately not bundled into this PR.

## Post-merge checklist

1. Trigger via Actions → Docker → Run workflow (version defaults to latest release).
2. Verify smoke green + manifest lists both platforms.
3. **Make the ghcr package public** (first publish defaults to private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)