### PR TITLE
chore(build): bump Go toolchain 1.23.2 -> 1.26.7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "rules_java", version = "8.16.1")
 bazel_dep(name = "rules_jvm_external", version = "6.8")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.23.2")
+go_sdk.download(version = "1.26.7")
 
 # External go deps
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -211,7 +211,7 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
+        "bzlTransitiveDigest": "03Qju4tW0vE+0RBuZGuV2A4Hx6AiSkdNahYvworx2aM=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -275,7 +275,7 @@
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "8vT1ddXtljNxYD0tJkksqzeKE6xqx4Ix+tXthAppjTI=",
+        "bzlTransitiveDigest": "xfNZ/WmfkC9N/pNH0cmucTOrqBa966d9iMmmX54m1UM=",
         "usagesDigest": "p80sy6cYQuWxx5jhV3fOTu+N9EyIUFG9+F7UC/nhXic=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},


### PR DESCRIPTION
## Summary

**Step 2 of the CVE-cleanup plan** (after #371, before tagging v0.5.3).

The released fizzbee binary embeds `go1.23.2` — ~2 years old, and the 1.23 line is past EOL, so Go stdlib security fixes no longer reach it. This bumps `go_sdk` to **1.26.7**, the latest patch of the currently-supported previous stable line (deliberately not 1.27.0, released days ago).

No scanner currently flags the old toolchain (scout: zero Go findings), so this is hygiene, not urgent — but unlike the rules_python refresh (deferred due to cross-compile breakage), a Go toolchain swap is low-risk and fully verifiable.

## Verification

- Reference suite: 98/98
- Cross-builds pass: linux_x86, linux_arm, macos_x86 (macos_arm native)
- Resulting binary embeds `go1.26.7` (`go version -m`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)