### PR TITLE
chore(docker): base image bookworm -> trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # `python`; the parser itself uses the tarball's bundled interpreter.
 
 # ---- Fetch ----------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM python:3.12-slim-bookworm AS fetch
+FROM --platform=$BUILDPLATFORM python:3.12-slim-trixie AS fetch
 
 ARG FIZZBEE_VERSION
 ARG TARGETARCH
@@ -52,7 +52,7 @@ RUN set -e; \
     test -x /opt/fizzbee/parser/parser_bin
 
 # ---- Runtime ---------------------------------------------------------------
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-trixie
 
 COPY --from=fetch /opt/fizzbee /opt/fizzbee
 


### PR DESCRIPTION
## Summary

One-line base switch: `python:3.12-slim-bookworm` → `python:3.12-slim-trixie` (both stages).

Debian 13 is current stable; bookworm is oldstable and only degrades from here. Scanner impact measured on the real v0.5.3 image:

| Base | C | H | M | L |
|---|---|---|---|---|
| bookworm | 2 | 3 | 17 | 41 |
| **trixie** | 2 | 2 | 11 | 29 |

(The remaining 2C/2H are the unfixed-upstream Debian perl CVEs present in every current Debian image; they clear via the monthly rebuild when Debian ships fixes.)

Python stays 3.12: in the thin-wrapper architecture the base python only bootstraps `mbt-scaffold` — the parser runs on the tarball's bundled interpreter. Newer python minors change no CVE outcome; alpine is impossible (bundled interpreter is glibc-linked); plain debian:slim would need an apt RUN step for python, breaking the QEMU-free multi-arch build.

## Verification

Built against the real v0.5.3 release on trixie: two-phase-commit passes with baseline output (331/281); mbt-scaffold (never previously tested on trixie) works; scout scan as above.

After merge: dispatch the Docker workflow once to republish `latest` on the new base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)